### PR TITLE
pnpm: Use workspace-wide prettier configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
-module.exports = { // E: 'module' is not defined.
+module.exports = {
+    // E: 'module' is not defined.
     extends: ['turbo', '@solana/eslint-config-solana', '@solana/eslint-config-solana/jest'],
     root: true,
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+docs
+lib
+test-ledger
+node_modules
+dist
+generated
+.mypy_cache
+*.yml
+*.yaml
+*.md
+*.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "printWidth": 120,
+    "trailingComma": "all",
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": true,
+    "endOfLine": "lf",
+    "arrowParens": "avoid"
+}
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,9 @@
 {
-    "printWidth": 120,
-    "trailingComma": "all",
-    "tabWidth": 4,
     "semi": true,
     "singleQuote": true,
-    "endOfLine": "lf",
-    "arrowParens": "avoid"
+    "trailingComma": "es5",
+    "useTabs": false,
+    "tabWidth": 4,
+    "arrowParens": "always",
+    "printWidth": 80
 }
-

--- a/account-compression/sdk/src/.prettierignore
+++ b/account-compression/sdk/src/.prettierignore
@@ -1,2 +1,0 @@
-test/dist
-docs/

--- a/account-compression/sdk/tests/accountCompression.test.ts
+++ b/account-compression/sdk/tests/accountCompression.test.ts
@@ -50,7 +50,7 @@ describe('Account Compression', () => {
 
         await provider.connection.confirmTransaction(
             await provider.connection.requestAirdrop(payer, 1e10),
-            'confirmed'
+            'confirmed',
         );
     });
 
@@ -71,7 +71,7 @@ describe('Account Compression', () => {
 
             assert(
                 Buffer.from(onChainRoot).equals(offChainTree.root),
-                'Updated on chain root matches root of updated off chain tree'
+                'Updated on chain root matches root of updated off chain tree',
             );
         });
         it('Verify proof works for that leaf', async () => {
@@ -90,7 +90,7 @@ describe('Account Compression', () => {
 
             assert(
                 Buffer.from(onChainRoot).equals(offChainTree.root),
-                'Updated on chain root matches root of updated off chain tree'
+                'Updated on chain root matches root of updated off chain tree',
             );
         });
         it('Verify leaf fails when proof fails', async () => {
@@ -121,7 +121,7 @@ describe('Account Compression', () => {
 
             assert(
                 Buffer.from(onChainRoot).equals(offChainTree.root),
-                'Updated on chain root matches root of updated off chain tree'
+                'Updated on chain root matches root of updated off chain tree',
             );
         });
         it('Replace that leaf', async () => {
@@ -140,7 +140,7 @@ describe('Account Compression', () => {
 
             assert(
                 Buffer.from(onChainRoot).equals(offChainTree.root),
-                'Updated on chain root matches root of updated off chain tree'
+                'Updated on chain root matches root of updated off chain tree',
             );
         });
 
@@ -159,7 +159,7 @@ describe('Account Compression', () => {
 
             assert(
                 Buffer.from(onChainRoot).equals(offChainTree.root),
-                'Updated on chain root matches root of updated off chain tree'
+                'Updated on chain root matches root of updated off chain tree',
             );
         });
     });
@@ -172,7 +172,7 @@ describe('Account Compression', () => {
 
         beforeEach(async () => {
             await provider.connection.confirmTransaction(
-                await (connection as Connection).requestAirdrop(authority, 1e10)
+                await (connection as Connection).requestAirdrop(authority, 1e10),
             );
             [cmtKeypair, offChainTree] = await createTreeOnChain(provider, authorityKeypair, 1, DEPTH_SIZE_PAIR);
             cmt = cmtKeypair.publicKey;
@@ -196,7 +196,7 @@ describe('Account Compression', () => {
 
             assert(
                 splCMT.getAuthority().equals(randomSigner),
-                `Upon transferring authority, authority should be ${randomSigner.toString()}, but was instead updated to ${splCMT.getAuthority()}`
+                `Upon transferring authority, authority should be ${randomSigner.toString()}, but was instead updated to ${splCMT.getAuthority()}`,
             );
 
             // Attempting to replace with new authority now works
@@ -245,7 +245,7 @@ describe('Account Compression', () => {
 
             assert(
                 Buffer.from(onChainRoot).equals(offChainTree.root),
-                'Updated on chain root does not match root of updated off chain tree'
+                'Updated on chain root does not match root of updated off chain tree',
             );
         });
         it('Empty all of the leaves and close the tree', async () => {
@@ -283,7 +283,7 @@ describe('Account Compression', () => {
             const finalLamports = payerInfo!.lamports;
             assert(
                 finalLamports === payerLamports + treeLamports - 5000,
-                'Expected payer to have received the lamports from the closed tree account'
+                'Expected payer to have received the lamports from the closed tree account',
             );
 
             treeInfo = await provider.connection.getAccountInfo(cmt, 'confirmed');
@@ -349,7 +349,7 @@ describe('Account Compression', () => {
 
             assert(
                 splCMT.getCurrentBufferIndex() === 0,
-                "CMT updated its active index after attacker's transaction, when it shouldn't have done anything"
+                "CMT updated its active index after attacker's transaction, when it shouldn't have done anything",
             );
         });
     });
@@ -361,7 +361,7 @@ describe('Account Compression', () => {
                 payerKeypair,
                 2 ** DEPTH,
                 { maxBufferSize: 8, maxDepth: DEPTH },
-                DEPTH // Store full tree on chain
+                DEPTH, // Store full tree on chain
             );
             cmt = cmtKeypair.publicKey;
 
@@ -391,7 +391,7 @@ describe('Account Compression', () => {
                 payerKeypair,
                 0,
                 { maxBufferSize: 8, maxDepth: DEPTH },
-                DEPTH // Store full tree on chain
+                DEPTH, // Store full tree on chain
             );
             cmt = cmtKeypair.publicKey;
 

--- a/account-compression/sdk/tests/accounts/concurrentMerkleTreeAccount.test.ts
+++ b/account-compression/sdk/tests/accounts/concurrentMerkleTreeAccount.test.ts
@@ -14,22 +14,22 @@ function assertCMTProperties(
     expectedMaxBufferSize: number,
     expectedAuthority: PublicKey,
     expectedRoot: Buffer,
-    expectedCanopyDepth?: number
+    expectedCanopyDepth?: number,
 ) {
     assert(
         onChainCMT.getMaxDepth() === expectedMaxDepth,
-        `Max depth does not match ${onChainCMT.getMaxDepth()}, expected ${expectedMaxDepth}`
+        `Max depth does not match ${onChainCMT.getMaxDepth()}, expected ${expectedMaxDepth}`,
     );
     assert(
         onChainCMT.getMaxBufferSize() === expectedMaxBufferSize,
-        `Max buffer size does not match ${onChainCMT.getMaxBufferSize()}, expected ${expectedMaxBufferSize}`
+        `Max buffer size does not match ${onChainCMT.getMaxBufferSize()}, expected ${expectedMaxBufferSize}`,
     );
     assert(onChainCMT.getAuthority().equals(expectedAuthority), 'Failed to write auth pubkey');
     assert(onChainCMT.getCurrentRoot().equals(expectedRoot), 'On chain root does not match root passed in instruction');
     if (expectedCanopyDepth) {
         assert(
             onChainCMT.getCanopyDepth() === expectedCanopyDepth,
-            'On chain canopy depth does not match expected canopy depth'
+            'On chain canopy depth does not match expected canopy depth',
         );
     }
 }
@@ -57,7 +57,7 @@ describe('ConcurrentMerkleTreeAccount tests', () => {
 
         await provider.connection.confirmTransaction(
             await provider.connection.requestAirdrop(payer, 1e10),
-            'confirmed'
+            'confirmed',
         );
     });
 
@@ -76,7 +76,7 @@ describe('ConcurrentMerkleTreeAccount tests', () => {
             const cmt = await ConcurrentMerkleTreeAccount.fromAccountAddress(
                 connection,
                 cmtKeypair.publicKey,
-                'confirmed'
+                'confirmed',
             );
 
             await assertCMTProperties(cmt, MAX_DEPTH, MAX_SIZE, payer, offChainTree.root);
@@ -97,7 +97,7 @@ describe('ConcurrentMerkleTreeAccount tests', () => {
                 const cmt = await ConcurrentMerkleTreeAccount.fromAccountAddress(
                     connection,
                     cmtKeypair.publicKey,
-                    'confirmed'
+                    'confirmed',
                 );
 
                 // Verify it was initialized correctly
@@ -106,7 +106,7 @@ describe('ConcurrentMerkleTreeAccount tests', () => {
                     depthSizePair.maxDepth,
                     depthSizePair.maxBufferSize,
                     payer,
-                    emptyNode(depthSizePair.maxDepth)
+                    emptyNode(depthSizePair.maxDepth),
                 );
             }
         });
@@ -129,12 +129,12 @@ describe('ConcurrentMerkleTreeAccount tests', () => {
                     provider,
                     payerKeypair,
                     { maxBufferSize, maxDepth },
-                    canopyDepth
+                    canopyDepth,
                 );
                 const cmt = await ConcurrentMerkleTreeAccount.fromAccountAddress(
                     connection,
                     cmtKeypair.publicKey,
-                    'confirmed'
+                    'confirmed',
                 );
 
                 // Verify it was initialized correctly

--- a/account-compression/sdk/tests/events/applicationData.test.ts
+++ b/account-compression/sdk/tests/events/applicationData.test.ts
@@ -1,27 +1,24 @@
-import { strict as assert } from "node:assert";
+import { strict as assert } from 'node:assert';
 
-import { BN } from "bn.js";
+import { BN } from 'bn.js';
 
-import { deserializeApplicationDataEvent } from "../../src";
+import { deserializeApplicationDataEvent } from '../../src';
 
-describe("Serde tests", () => {
-  describe("ApplicationDataEvent tests", () => {
-    it("Can serialize and deserialize ApplicationDataEvent", () => {
-      const data = Buffer.from("Hello world");
-      const applicationDataEvent = Buffer.concat([
-        Buffer.from([0x1]), // ApplicationData Event tag
-        Buffer.from([0x0]), // version 0 tag
-        Buffer.from(new BN.BN(data.length).toArray("le", 4)), // Size of application data (for Vec)
-        data, // serialized application data (for Vec)
-      ]);
+describe('Serde tests', () => {
+    describe('ApplicationDataEvent tests', () => {
+        it('Can serialize and deserialize ApplicationDataEvent', () => {
+            const data = Buffer.from('Hello world');
+            const applicationDataEvent = Buffer.concat([
+                Buffer.from([0x1]), // ApplicationData Event tag
+                Buffer.from([0x0]), // version 0 tag
+                Buffer.from(new BN.BN(data.length).toArray('le', 4)), // Size of application data (for Vec)
+                data, // serialized application data (for Vec)
+            ]);
 
-      const deserialized =
-        deserializeApplicationDataEvent(applicationDataEvent);
-      const decoder = new TextDecoder();
-      const deserializedData = decoder.decode(
-        deserialized.fields[0].applicationData
-      );
-      assert("Hello world" === deserializedData);
+            const deserialized = deserializeApplicationDataEvent(applicationDataEvent);
+            const decoder = new TextDecoder();
+            const deserializedData = decoder.decode(deserialized.fields[0].applicationData);
+            assert('Hello world' === deserializedData);
+        });
     });
-  });
 });

--- a/account-compression/sdk/tests/events/changelog.test.ts
+++ b/account-compression/sdk/tests/events/changelog.test.ts
@@ -1,116 +1,100 @@
-import { strict as assert } from "node:assert";
+import { strict as assert } from 'node:assert';
 
-import { AnchorProvider } from "@coral-xyz/anchor";
-import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
-import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
-import { Connection, Keypair, PublicKey } from "@solana/web3.js";
-import { BN } from "bn.js";
-import * as crypto from "crypto";
+import { AnchorProvider } from '@coral-xyz/anchor';
+import NodeWallet from '@coral-xyz/anchor/dist/cjs/nodewallet';
+import { bs58 } from '@coral-xyz/anchor/dist/cjs/utils/bytes';
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import { BN } from 'bn.js';
+import * as crypto from 'crypto';
 
-import {
-  createAppendIx,
-  deserializeChangeLogEventV1,
-  SPL_NOOP_PROGRAM_ID,
-} from "../../src";
-import { MerkleTree } from "../../src/merkle-tree";
-import { createTreeOnChain,execute } from "../utils";
+import { createAppendIx, deserializeChangeLogEventV1, SPL_NOOP_PROGRAM_ID } from '../../src';
+import { MerkleTree } from '../../src/merkle-tree';
+import { createTreeOnChain, execute } from '../utils';
 
-describe("Serde tests", () => {
-  let offChainTree: MerkleTree;
-  let cmtKeypair: Keypair;
-  let payerKeypair: Keypair;
-  let payer: PublicKey;
-  let connection: Connection;
-  let provider: AnchorProvider;
+describe('Serde tests', () => {
+    let offChainTree: MerkleTree;
+    let cmtKeypair: Keypair;
+    let payerKeypair: Keypair;
+    let payer: PublicKey;
+    let connection: Connection;
+    let provider: AnchorProvider;
 
-  const MAX_SIZE = 64;
-  const MAX_DEPTH = 14;
+    const MAX_SIZE = 64;
+    const MAX_DEPTH = 14;
 
-  beforeEach(async () => {
-    payerKeypair = Keypair.generate();
-    payer = payerKeypair.publicKey;
-
-    connection = new Connection("http://127.0.0.1:8899", {
-      commitment: "confirmed",
-    });
-    const wallet = new NodeWallet(payerKeypair);
-    provider = new AnchorProvider(connection, wallet, {
-      commitment: connection.commitment,
-      skipPreflight: true,
-    });
-
-    await provider.connection.confirmTransaction(
-      await provider.connection.requestAirdrop(payer, 1e10),
-      "confirmed"
-    );
-  });
-  describe("ChangeLogEvent tests", () => {
-    let cmt: PublicKey;
     beforeEach(async () => {
-      [cmtKeypair, offChainTree] = await createTreeOnChain(
-        provider,
-        payerKeypair,
-        0,
-        { maxBufferSize: MAX_SIZE, maxDepth: MAX_DEPTH }
-      );
-      cmt = cmtKeypair.publicKey;
+        payerKeypair = Keypair.generate();
+        payer = payerKeypair.publicKey;
+
+        connection = new Connection('http://127.0.0.1:8899', {
+            commitment: 'confirmed',
+        });
+        const wallet = new NodeWallet(payerKeypair);
+        provider = new AnchorProvider(connection, wallet, {
+            commitment: connection.commitment,
+            skipPreflight: true,
+        });
+
+        await provider.connection.confirmTransaction(
+            await provider.connection.requestAirdrop(payer, 1e10),
+            'confirmed',
+        );
     });
-    it("Can deserialize a ChangeLogEvent", async () => {
-      const newLeaf = crypto.randomBytes(32);
-      const txId = await execute(
-        provider,
-        [createAppendIx(cmt, payer, newLeaf)],
-        [payerKeypair]
-      );
-      offChainTree.updateLeaf(0, newLeaf);
+    describe('ChangeLogEvent tests', () => {
+        let cmt: PublicKey;
+        beforeEach(async () => {
+            [cmtKeypair, offChainTree] = await createTreeOnChain(provider, payerKeypair, 0, {
+                maxBufferSize: MAX_SIZE,
+                maxDepth: MAX_DEPTH,
+            });
+            cmt = cmtKeypair.publicKey;
+        });
+        it('Can deserialize a ChangeLogEvent', async () => {
+            const newLeaf = crypto.randomBytes(32);
+            const txId = await execute(provider, [createAppendIx(cmt, payer, newLeaf)], [payerKeypair]);
+            offChainTree.updateLeaf(0, newLeaf);
 
-      const transaction = await connection.getTransaction(txId, {
-        commitment: "confirmed",
-        maxSupportedTransactionVersion: 2,
-      });
+            const transaction = await connection.getTransaction(txId, {
+                commitment: 'confirmed',
+                maxSupportedTransactionVersion: 2,
+            });
 
-      // Get noop program instruction
-      const accountKeys = transaction!.transaction.message.getAccountKeys();
-      const noopInstruction =
-        transaction!.meta!.innerInstructions![0].instructions[0];
-      const programId = accountKeys.get(noopInstruction.programIdIndex)!;
-      if (!programId.equals(SPL_NOOP_PROGRAM_ID)) {
-        throw Error(
-          `Only inner ix should be a noop, but instead is a ${programId.toBase58()}`
-        );
-      }
-      const cpiData = Buffer.from(bs58.decode(noopInstruction.data));
-      const changeLogEvent = deserializeChangeLogEventV1(cpiData);
+            // Get noop program instruction
+            const accountKeys = transaction!.transaction.message.getAccountKeys();
+            const noopInstruction = transaction!.meta!.innerInstructions![0].instructions[0];
+            const programId = accountKeys.get(noopInstruction.programIdIndex)!;
+            if (!programId.equals(SPL_NOOP_PROGRAM_ID)) {
+                throw Error(`Only inner ix should be a noop, but instead is a ${programId.toBase58()}`);
+            }
+            const cpiData = Buffer.from(bs58.decode(noopInstruction.data));
+            const changeLogEvent = deserializeChangeLogEventV1(cpiData);
 
-      assert(
-        changeLogEvent.treeId.equals(cmt),
-        `Tree id in changeLog differs from expected tree ${cmt.toBase58()}`
-      );
-      assert(
-        changeLogEvent.index === 0,
-        `ChangeLog should have index 0, but has index ${changeLogEvent.index}`
-      );
-      assert(
-        new BN.BN(changeLogEvent.seq).toNumber() === 1,
-        `ChangeLog should have sequence number of 1, but has seq number of ${changeLogEvent.seq.toString()}`
-      );
+            assert(
+                changeLogEvent.treeId.equals(cmt),
+                `Tree id in changeLog differs from expected tree ${cmt.toBase58()}`,
+            );
+            assert(changeLogEvent.index === 0, `ChangeLog should have index 0, but has index ${changeLogEvent.index}`);
+            assert(
+                new BN.BN(changeLogEvent.seq).toNumber() === 1,
+                `ChangeLog should have sequence number of 1, but has seq number of ${changeLogEvent.seq.toString()}`,
+            );
 
-      // Check that the emitted ChangeLog path matches up with the updated Tree
-      let nodeIndex = 0 + (1 << MAX_DEPTH);
-      let realTreeNode = offChainTree.leaves[0];
-      while (nodeIndex > 0) {
-        const clNode = changeLogEvent.path.shift()!;
-        assert(
-          nodeIndex === clNode.index,
-          `Expected changeLog index to be ${nodeIndex} but is ${clNode.index}`
-        );
-        assert(
-          realTreeNode!.node.equals(Buffer.from(clNode.node)),
-          `ChangeLog node differs at node index: ${clNode.index}`
-        );
-        realTreeNode = realTreeNode.parent!;
-        nodeIndex = nodeIndex >> 1;
-      }
+            // Check that the emitted ChangeLog path matches up with the updated Tree
+            let nodeIndex = 0 + (1 << MAX_DEPTH);
+            let realTreeNode = offChainTree.leaves[0];
+            while (nodeIndex > 0) {
+                const clNode = changeLogEvent.path.shift()!;
+                assert(
+                    nodeIndex === clNode.index,
+                    `Expected changeLog index to be ${nodeIndex} but is ${clNode.index}`,
+                );
+                assert(
+                    realTreeNode!.node.equals(Buffer.from(clNode.node)),
+                    `ChangeLog node differs at node index: ${clNode.index}`,
+                );
+                realTreeNode = realTreeNode.parent!;
+                nodeIndex = nodeIndex >> 1;
+            }
+        });
     });
-  });
 });

--- a/account-compression/sdk/tests/merkleTree.test.ts
+++ b/account-compression/sdk/tests/merkleTree.test.ts
@@ -1,35 +1,31 @@
-import { strict as assert } from "node:assert";
+import { strict as assert } from 'node:assert';
 
-import * as crypto from "crypto";
+import * as crypto from 'crypto';
 
-import { emptyNode, MerkleTree } from "../src";
+import { emptyNode, MerkleTree } from '../src';
 
-describe("MerkleTree tests", () => {
-  it("Check constructor equivalence for depth 2 tree", () => {
-    const leaves = [
-      crypto.randomBytes(32),
-      crypto.randomBytes(32),
-      crypto.randomBytes(32),
-    ];
-    const rawLeaves = leaves.concat(emptyNode(0));
-    const merkleTreeRaw = new MerkleTree(rawLeaves);
-    const merkleTreeSparse = MerkleTree.sparseMerkleTreeFromLeaves(leaves, 2);
+describe('MerkleTree tests', () => {
+    it('Check constructor equivalence for depth 2 tree', () => {
+        const leaves = [crypto.randomBytes(32), crypto.randomBytes(32), crypto.randomBytes(32)];
+        const rawLeaves = leaves.concat(emptyNode(0));
+        const merkleTreeRaw = new MerkleTree(rawLeaves);
+        const merkleTreeSparse = MerkleTree.sparseMerkleTreeFromLeaves(leaves, 2);
 
-    assert(merkleTreeRaw.root.equals(merkleTreeSparse.root));
-  });
+        assert(merkleTreeRaw.root.equals(merkleTreeSparse.root));
+    });
 
-  const TEST_DEPTH = 14;
-  it(`Check proofs for 2^${TEST_DEPTH} tree`, () => {
-    const leaves: Buffer[] = [];
-    for (let i = 0; i < 2 ** TEST_DEPTH; i++) {
-      leaves.push(crypto.randomBytes(32));
-    }
-    const merkleTree = new MerkleTree(leaves);
+    const TEST_DEPTH = 14;
+    it(`Check proofs for 2^${TEST_DEPTH} tree`, () => {
+        const leaves: Buffer[] = [];
+        for (let i = 0; i < 2 ** TEST_DEPTH; i++) {
+            leaves.push(crypto.randomBytes(32));
+        }
+        const merkleTree = new MerkleTree(leaves);
 
-    // Check proofs
-    for (let i = 0; i < leaves.length; i++) {
-      const proof = merkleTree.getProof(i);
-      assert(MerkleTree.verify(merkleTree.getRoot(), proof));
-    }
-  });
+        // Check proofs
+        for (let i = 0; i < leaves.length; i++) {
+            const proof = merkleTree.getProof(i);
+            assert(MerkleTree.verify(merkleTree.getRoot(), proof));
+        }
+    });
 });

--- a/account-compression/sdk/tests/utils.ts
+++ b/account-compression/sdk/tests/utils.ts
@@ -23,7 +23,7 @@ export async function execute(
     instructions: TransactionInstruction[],
     signers: Signer[],
     skipPreflight = false,
-    verbose = false
+    verbose = false,
 ): Promise<string> {
     let tx = new Transaction();
     instructions.map(ix => {
@@ -38,7 +38,7 @@ export async function execute(
     } catch (e) {
         if (e instanceof SendTransactionError) {
             console.log('Tx error!', e.logs);
-	}
+        }
         throw e;
     }
 
@@ -54,7 +54,7 @@ export async function createTreeOnChain(
     payer: Keypair,
     numLeaves: number,
     depthSizePair: ValidDepthSizePair,
-    canopyDepth = 0
+    canopyDepth = 0,
 ): Promise<[Keypair, MerkleTree]> {
     const cmtKeypair = Keypair.generate();
 
@@ -69,7 +69,7 @@ export async function createTreeOnChain(
         cmtKeypair.publicKey,
         payer.publicKey,
         depthSizePair,
-        canopyDepth
+        canopyDepth,
     );
 
     const ixs = [allocAccountIx, createInitEmptyMerkleTreeIx(cmtKeypair.publicKey, payer.publicKey, depthSizePair)];
@@ -97,7 +97,7 @@ export async function createEmptyTreeOnChain(
     provider: AnchorProvider,
     payer: Keypair,
     depthSizePair: ValidDepthSizePair,
-    canopyDepth = 0
+    canopyDepth = 0,
 ): Promise<Keypair> {
     const cmtKeypair = Keypair.generate();
     const allocAccountIx = await createAllocTreeIx(
@@ -105,7 +105,7 @@ export async function createEmptyTreeOnChain(
         cmtKeypair.publicKey,
         payer.publicKey,
         depthSizePair,
-        canopyDepth
+        canopyDepth,
     );
 
     const ixs = [allocAccountIx, createInitEmptyMerkleTreeIx(cmtKeypair.publicKey, payer.publicKey, depthSizePair)];

--- a/libraries/type-length-value/js/.prettierignore
+++ b/libraries/type-length-value/js/.prettierignore
@@ -1,5 +1,0 @@
-docs
-lib
-test-ledger
-
-package-lock.json

--- a/libraries/type-length-value/js/.prettierrc
+++ b/libraries/type-length-value/js/.prettierrc
@@ -1,7 +1,0 @@
-{
-    "printWidth": 120,
-    "trailingComma": "es5",
-    "tabWidth": 4,
-    "semi": true,
-    "singleQuote": true
-}

--- a/libraries/type-length-value/js/test/splDiscriminate.test.ts
+++ b/libraries/type-length-value/js/test/splDiscriminate.test.ts
@@ -10,7 +10,7 @@ describe('splDiscrimintor', () => {
         'test-namespace:this-is-a-test:with-a-longer-name',
     ];
 
-    const testExpectedBytes = testVectors.map((x) => {
+    const testExpectedBytes = testVectors.map(x => {
         return createHash('sha256').update(x).digest();
     });
 

--- a/managed-token/sdk/.solitarc.js
+++ b/managed-token/sdk/.solitarc.js
@@ -1,14 +1,14 @@
-const path = require("path");
-const programDir = path.join(__dirname, "..", "program");
-const idlDir = path.join(__dirname, "idl");
-const sdkDir = path.join(__dirname, "src", "generated");
-const binaryInstallDir = path.join(__dirname, "..", "..", "target", "solita");
+const path = require('path');
+const programDir = path.join(__dirname, '..', 'program');
+const idlDir = path.join(__dirname, 'idl');
+const sdkDir = path.join(__dirname, 'src', 'generated');
+const binaryInstallDir = path.join(__dirname, '..', '..', 'target', 'solita');
 
 module.exports = {
-  idlGenerator: "shank",
-  programName: "spl_managed_token",
-  idlDir,
-  sdkDir,
-  binaryInstallDir,
-  programDir,
+    idlGenerator: 'shank',
+    programName: 'spl_managed_token',
+    idlDir,
+    sdkDir,
+    binaryInstallDir,
+    programDir,
 };

--- a/memo/js/.prettierignore
+++ b/memo/js/.prettierignore
@@ -1,5 +1,0 @@
-docs
-lib
-test-ledger
-
-package-lock.json

--- a/memo/js/.prettierrc
+++ b/memo/js/.prettierrc
@@ -1,7 +1,0 @@
-{
-    "printWidth": 120,
-    "trailingComma": "es5",
-    "tabWidth": 4,
-    "semi": true,
-    "singleQuote": true
-}

--- a/name-service/js/.prettierignore
+++ b/name-service/js/.prettierignore
@@ -1,5 +1,0 @@
-docs
-lib
-test-ledger
-
-package-lock.json

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "build:program": "turbo run build:program",
         "clean": "turbo run clean",
         "lint": "turbo run lint",
-        "lint:fix": "turbo run lint:fix",
+        "format": "prettier --check .",
+        "format:fix": "prettier --write .",
         "test": "turbo run test"
     },
     "devDependencies": {

--- a/token-group/js/.prettierignore
+++ b/token-group/js/.prettierignore
@@ -1,5 +1,0 @@
-docs
-lib
-test-ledger
-
-package-lock.json

--- a/token-group/js/.prettierrc
+++ b/token-group/js/.prettierrc
@@ -1,7 +1,0 @@
-{
-    "printWidth": 120,
-    "trailingComma": "es5",
-    "tabWidth": 4,
-    "semi": true,
-    "singleQuote": true
-}

--- a/token-group/js/src/instruction.ts
+++ b/token-group/js/src/instruction.ts
@@ -47,8 +47,8 @@ export function createInitializeGroupInstruction(args: InitializeGroupInstructio
                 getStructEncoder([
                     ['updateAuthority', getPublicKeyEncoder()],
                     ['maxSize', getU32Encoder()],
-                ])
-            ).encode({ updateAuthority: updateAuthority ?? SystemProgram.programId, maxSize })
+                ]),
+            ).encode({ updateAuthority: updateAuthority ?? SystemProgram.programId, maxSize }),
         ),
     });
 }
@@ -71,8 +71,8 @@ export function createUpdateGroupMaxSizeInstruction(args: UpdateGroupMaxSize): T
         data: Buffer.from(
             getInstructionEncoder(
                 splDiscriminate('spl_token_group_interface:update_group_max_size'),
-                getStructEncoder([['maxSize', getU32Encoder()]])
-            ).encode({ maxSize })
+                getStructEncoder([['maxSize', getU32Encoder()]]),
+            ).encode({ maxSize }),
         ),
     });
 }
@@ -96,8 +96,8 @@ export function createUpdateGroupAuthorityInstruction(args: UpdateGroupAuthority
         data: Buffer.from(
             getInstructionEncoder(
                 splDiscriminate('spl_token_group_interface:update_authority'),
-                getStructEncoder([['newAuthority', getPublicKeyEncoder()]])
-            ).encode({ newAuthority: newAuthority ?? SystemProgram.programId })
+                getStructEncoder([['newAuthority', getPublicKeyEncoder()]]),
+            ).encode({ newAuthority: newAuthority ?? SystemProgram.programId }),
         ),
     });
 }
@@ -126,8 +126,8 @@ export function createInitializeMemberInstruction(args: InitializeMember): Trans
         data: Buffer.from(
             getInstructionEncoder(
                 splDiscriminate('spl_token_group_interface:initialize_member'),
-                getStructEncoder([])
-            ).encode({})
+                getStructEncoder([]),
+            ).encode({}),
         ),
     });
 }

--- a/token-group/js/test/instruction.test.ts
+++ b/token-group/js/test/instruction.test.ts
@@ -15,7 +15,7 @@ function checkPackUnpack<T extends object>(
     instruction: TransactionInstruction,
     discriminator: Uint8Array,
     decoder: Decoder<T>,
-    values: T
+    values: T,
 ) {
     expect(instruction.data.subarray(0, 8)).to.deep.equal(discriminator);
     const unpacked = decoder.decode(instruction.data.subarray(8));
@@ -45,7 +45,7 @@ describe('Token Group Instructions', () => {
                 ['updateAuthority', fixDecoderSize(getBytesDecoder(), 32)],
                 ['maxSize', getU32Decoder()],
             ]),
-            { updateAuthority: Uint8Array.from(updateAuthority.toBuffer()), maxSize }
+            { updateAuthority: Uint8Array.from(updateAuthority.toBuffer()), maxSize },
         );
     });
 
@@ -59,7 +59,7 @@ describe('Token Group Instructions', () => {
             }),
             splDiscriminate('spl_token_group_interface:update_group_max_size'),
             getStructDecoder([['maxSize', getU32Decoder()]]),
-            { maxSize }
+            { maxSize },
         );
     });
 
@@ -73,7 +73,7 @@ describe('Token Group Instructions', () => {
             }),
             splDiscriminate('spl_token_group_interface:update_authority'),
             getStructDecoder([['newAuthority', fixDecoderSize(getBytesDecoder(), 32)]]),
-            { newAuthority: Uint8Array.from(PublicKey.default.toBuffer()) }
+            { newAuthority: Uint8Array.from(PublicKey.default.toBuffer()) },
         );
     });
 
@@ -95,7 +95,7 @@ describe('Token Group Instructions', () => {
             }),
             splDiscriminate('spl_token_group_interface:initialize_member'),
             getStructDecoder([]),
-            {}
+            {},
         );
     });
 });

--- a/token-lending/js/.prettierignore
+++ b/token-lending/js/.prettierignore
@@ -1,2 +1,0 @@
-docs
-lib

--- a/token-lending/js/.prettierrc
+++ b/token-lending/js/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "printWidth": 120,
-  "trailingComma": "es5",
-  "tabWidth": 4,
-  "semi": true,
-  "singleQuote": true
-}

--- a/token-lending/js/src/instructions/borrowObligationLiquidity.ts
+++ b/token-lending/js/src/instructions/borrowObligationLiquidity.ts
@@ -22,7 +22,7 @@ export const borrowObligationLiquidityInstruction = (
     lendingMarket: PublicKey,
     lendingMarketAuthority: PublicKey,
     obligationOwner: PublicKey,
-    hostFeeReceiver?: PublicKey
+    hostFeeReceiver?: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -30,7 +30,7 @@ export const borrowObligationLiquidityInstruction = (
             instruction: LendingInstruction.BorrowObligationLiquidity,
             liquidityAmount: BigInt(liquidityAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/depositObligationCollateral.ts
+++ b/token-lending/js/src/instructions/depositObligationCollateral.ts
@@ -20,7 +20,7 @@ export const depositObligationCollateralInstruction = (
     obligation: PublicKey,
     lendingMarket: PublicKey,
     obligationOwner: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -28,7 +28,7 @@ export const depositObligationCollateralInstruction = (
             instruction: LendingInstruction.DepositObligationCollateral,
             collateralAmount: BigInt(collateralAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/depositReserveLiquidity.ts
+++ b/token-lending/js/src/instructions/depositReserveLiquidity.ts
@@ -21,7 +21,7 @@ export const depositReserveLiquidityInstruction = (
     reserveCollateralMint: PublicKey,
     lendingMarket: PublicKey,
     lendingMarketAuthority: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -29,7 +29,7 @@ export const depositReserveLiquidityInstruction = (
             instruction: LendingInstruction.DepositReserveLiquidity,
             liquidityAmount: BigInt(liquidityAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/flashLoan.ts
+++ b/token-lending/js/src/instructions/flashLoan.ts
@@ -22,7 +22,7 @@ export const flashLoanInstruction = (
     lendingMarket: PublicKey,
     lendingMarketAuthority: PublicKey,
     flashLoanProgram: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -30,7 +30,7 @@ export const flashLoanInstruction = (
             instruction: LendingInstruction.FlashLoan,
             liquidityAmount: BigInt(liquidityAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/initLendingMarket.ts
+++ b/token-lending/js/src/instructions/initLendingMarket.ts
@@ -16,7 +16,7 @@ const DataLayout = struct<Data>([u8('instruction'), publicKey('owner'), blob(32,
 export const initLendingMarketInstruction = (
     owner: PublicKey,
     quoteCurrency: Uint8Array,
-    lendingMarket: PublicKey
+    lendingMarket: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -25,7 +25,7 @@ export const initLendingMarketInstruction = (
             owner,
             quoteCurrency,
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/initObligation.ts
+++ b/token-lending/js/src/instructions/initObligation.ts
@@ -13,7 +13,7 @@ const DataLayout = struct<Data>([u8('instruction')]);
 export const initObligationInstruction = (
     obligation: PublicKey,
     lendingMarket: PublicKey,
-    obligationOwner: PublicKey
+    obligationOwner: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode({ instruction: LendingInstruction.InitObligation }, data);

--- a/token-lending/js/src/instructions/initReserve.ts
+++ b/token-lending/js/src/instructions/initReserve.ts
@@ -30,7 +30,7 @@ export const initReserveInstruction = (
     lendingMarket: PublicKey,
     lendingMarketAuthority: PublicKey,
     lendingMarketOwner: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -39,7 +39,7 @@ export const initReserveInstruction = (
             liquidityAmount: BigInt(liquidityAmount),
             config,
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/liquidateObligation.ts
+++ b/token-lending/js/src/instructions/liquidateObligation.ts
@@ -23,7 +23,7 @@ export const liquidateObligationInstruction = (
     obligation: PublicKey,
     lendingMarket: PublicKey,
     lendingMarketAuthority: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -31,7 +31,7 @@ export const liquidateObligationInstruction = (
             instruction: LendingInstruction.LiquidateObligation,
             liquidityAmount: BigInt(liquidityAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/redeemReserveCollateral.ts
+++ b/token-lending/js/src/instructions/redeemReserveCollateral.ts
@@ -21,7 +21,7 @@ export const redeemReserveCollateralInstruction = (
     reserveLiquiditySupply: PublicKey,
     lendingMarket: PublicKey,
     lendingMarketAuthority: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -29,7 +29,7 @@ export const redeemReserveCollateralInstruction = (
             instruction: LendingInstruction.RedeemReserveCollateral,
             collateralAmount: BigInt(collateralAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/refreshObligation.ts
+++ b/token-lending/js/src/instructions/refreshObligation.ts
@@ -12,7 +12,7 @@ const DataLayout = struct<Data>([u8('instruction')]);
 export const refreshObligationInstruction = (
     obligation: PublicKey,
     depositReserves: PublicKey[],
-    borrowReserves: PublicKey[]
+    borrowReserves: PublicKey[],
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode({ instruction: LendingInstruction.RefreshObligation }, data);

--- a/token-lending/js/src/instructions/repayObligationLiquidity.ts
+++ b/token-lending/js/src/instructions/repayObligationLiquidity.ts
@@ -19,7 +19,7 @@ export const repayObligationLiquidityInstruction = (
     repayReserve: PublicKey,
     obligation: PublicKey,
     lendingMarket: PublicKey,
-    transferAuthority: PublicKey
+    transferAuthority: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -27,7 +27,7 @@ export const repayObligationLiquidityInstruction = (
             instruction: LendingInstruction.RepayObligationLiquidity,
             liquidityAmount: BigInt(liquidityAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/setLendingMarketOwner.ts
+++ b/token-lending/js/src/instructions/setLendingMarketOwner.ts
@@ -14,7 +14,7 @@ const DataLayout = struct<Data>([u8('instruction'), publicKey('newOwner')]);
 export const setLendingMarketOwnerInstruction = (
     newOwner: PublicKey,
     lendingMarket: PublicKey,
-    currentOwner: PublicKey
+    currentOwner: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -22,7 +22,7 @@ export const setLendingMarketOwnerInstruction = (
             instruction: LendingInstruction.SetLendingMarketOwner,
             newOwner,
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/instructions/withdrawObligationCollateral.ts
+++ b/token-lending/js/src/instructions/withdrawObligationCollateral.ts
@@ -20,7 +20,7 @@ export const withdrawObligationCollateralInstruction = (
     obligation: PublicKey,
     lendingMarket: PublicKey,
     lendingMarketAuthority: PublicKey,
-    obligationOwner: PublicKey
+    obligationOwner: PublicKey,
 ): TransactionInstruction => {
     const data = Buffer.alloc(DataLayout.span);
     DataLayout.encode(
@@ -28,7 +28,7 @@ export const withdrawObligationCollateralInstruction = (
             instruction: LendingInstruction.WithdrawObligationCollateral,
             collateralAmount: BigInt(collateralAmount),
         },
-        data
+        data,
     );
 
     const keys = [

--- a/token-lending/js/src/state/lendingMarket.ts
+++ b/token-lending/js/src/state/lendingMarket.ts
@@ -23,7 +23,7 @@ export const LendingMarketLayout = struct<LendingMarket>(
         publicKey('oracleProgramId'),
         blob(128, 'padding'),
     ],
-    'lendingMarket'
+    'lendingMarket',
 );
 
 export const LENDING_MARKET_SIZE = LendingMarketLayout.span;

--- a/token-lending/js/src/state/obligation.ts
+++ b/token-lending/js/src/state/obligation.ts
@@ -49,7 +49,7 @@ export interface ObligationDataFlat {
 /** @internal */
 export const ObligationCollateralLayout = struct<ObligationCollateral>(
     [publicKey('depositReserve'), u64('depositedAmount'), decimal('marketValue')],
-    'collateral'
+    'collateral',
 );
 
 /** @internal */
@@ -60,7 +60,7 @@ export const ObligationLiquidityLayout = struct<ObligationLiquidity>(
         decimal('borrowedAmountWads'),
         decimal('marketValue'),
     ],
-    'liquidity'
+    'liquidity',
 );
 
 /** @internal */
@@ -78,7 +78,7 @@ export const ObligationLayout = struct<ObligationDataFlat>(
         u8('borrowsLen'),
         blob(ObligationCollateralLayout.span + 9 * ObligationLiquidityLayout.span, 'dataFlat'),
     ],
-    'obligation'
+    'obligation',
 );
 
 export const OBLIGATION_SIZE = ObligationLayout.span;

--- a/token-lending/js/src/state/reserve.ts
+++ b/token-lending/js/src/state/reserve.ts
@@ -63,19 +63,19 @@ export const ReserveLiquidityLayout = struct<ReserveLiquidity>(
         decimal('cumulativeBorrowRateWads'),
         decimal('marketPrice'),
     ],
-    'liquidity'
+    'liquidity',
 );
 
 /** @internal */
 export const ReserveCollateralLayout = struct<ReserveCollateral>(
     [publicKey('mintPubkey'), u64('mintTotalSupply'), publicKey('supplyPubkey')],
-    'collateral'
+    'collateral',
 );
 
 /** @internal */
 export const ReserveFeesLayout = struct<ReserveFees>(
     [u64('borrowFeeWad'), u64('flashLoanFeeWad'), u8('hostFeePercentage')],
-    'fees'
+    'fees',
 );
 
 /** @internal */
@@ -90,7 +90,7 @@ export const ReserveConfigLayout = struct<ReserveConfig>(
         u8('maxBorrowRate'),
         ReserveFeesLayout,
     ],
-    'config'
+    'config',
 );
 
 /** @internal */

--- a/token-lending/js/src/util/layout.ts
+++ b/token-lending/js/src/util/layout.ts
@@ -2,7 +2,7 @@ import { AccountInfo, PublicKey } from '@solana/web3.js';
 
 export type Parser<T> = (
     pubkey: PublicKey,
-    info: AccountInfo<Uint8Array>
+    info: AccountInfo<Uint8Array>,
 ) =>
     | {
           pubkey: PublicKey;

--- a/token-metadata/js/.prettierignore
+++ b/token-metadata/js/.prettierignore
@@ -1,5 +1,0 @@
-docs
-lib
-test-ledger
-
-package-lock.json

--- a/token-metadata/js/.prettierrc
+++ b/token-metadata/js/.prettierrc
@@ -1,7 +1,0 @@
-{
-    "printWidth": 120,
-    "trailingComma": "es5",
-    "tabWidth": 4,
-    "semi": true,
-    "singleQuote": true
-}

--- a/token-metadata/js/src/instruction.ts
+++ b/token-metadata/js/src/instruction.ts
@@ -71,8 +71,8 @@ export function createInitializeInstruction(args: InitializeInstructionArgs): Tr
                     ['name', getStringEncoder()],
                     ['symbol', getStringEncoder()],
                     ['uri', getStringEncoder()],
-                ])
-            ).encode({ name, symbol, uri })
+                ]),
+            ).encode({ name, symbol, uri }),
         ),
     });
 }
@@ -103,8 +103,8 @@ export function createUpdateFieldInstruction(args: UpdateFieldInstruction): Tran
                 getStructEncoder([
                     ['field', getDataEnumCodec(getFieldCodec())],
                     ['value', getStringEncoder()],
-                ])
-            ).encode({ field: getFieldConfig(field), value })
+                ]),
+            ).encode({ field: getFieldConfig(field), value }),
         ),
     });
 }
@@ -131,8 +131,8 @@ export function createRemoveKeyInstruction(args: RemoveKeyInstructionArgs) {
                 getStructEncoder([
                     ['idempotent', getBooleanEncoder()],
                     ['key', getStringEncoder()],
-                ])
-            ).encode({ idempotent, key })
+                ]),
+            ).encode({ idempotent, key }),
         ),
     });
 }
@@ -156,8 +156,8 @@ export function createUpdateAuthorityInstruction(args: UpdateAuthorityInstructio
         data: Buffer.from(
             getInstructionEncoder(
                 splDiscriminate('spl_token_metadata_interface:update_the_authority'),
-                getStructEncoder([['newAuthority', getPublicKeyEncoder()]])
-            ).encode({ newAuthority: newAuthority ?? SystemProgram.programId })
+                getStructEncoder([['newAuthority', getPublicKeyEncoder()]]),
+            ).encode({ newAuthority: newAuthority ?? SystemProgram.programId }),
         ),
     });
 }
@@ -180,8 +180,8 @@ export function createEmitInstruction(args: EmitInstructionArgs): TransactionIns
                 getStructEncoder([
                     ['start', getOptionEncoder(getU64Encoder())],
                     ['end', getOptionEncoder(getU64Encoder())],
-                ])
-            ).encode({ start: start ?? null, end: end ?? null })
+                ]),
+            ).encode({ start: start ?? null, end: end ?? null }),
         ),
     });
 }

--- a/token-metadata/js/test/instruction.test.ts
+++ b/token-metadata/js/test/instruction.test.ts
@@ -30,7 +30,7 @@ function checkPackUnpack<T extends object>(
     instruction: TransactionInstruction,
     discriminator: Uint8Array,
     decoder: Decoder<T>,
-    values: T
+    values: T,
 ) {
     expect(instruction.data.subarray(0, 8)).to.deep.equal(discriminator);
     const unpacked = decoder.decode(instruction.data.subarray(8));
@@ -69,7 +69,7 @@ describe('Token Metadata Instructions', () => {
                 ['symbol', getStringDecoder()],
                 ['uri', getStringDecoder()],
             ]),
-            { name, symbol, uri }
+            { name, symbol, uri },
         );
     });
 
@@ -89,7 +89,7 @@ describe('Token Metadata Instructions', () => {
                 ['key', getDataEnumCodec(getFieldCodec())],
                 ['value', getStringDecoder()],
             ]),
-            { key: getFieldConfig(field), value }
+            { key: getFieldConfig(field), value },
         );
     });
 
@@ -109,7 +109,7 @@ describe('Token Metadata Instructions', () => {
                 ['key', getDataEnumCodec(getFieldCodec())],
                 ['value', getStringDecoder()],
             ]),
-            { key: getFieldConfig(field), value }
+            { key: getFieldConfig(field), value },
         );
     });
 
@@ -127,7 +127,7 @@ describe('Token Metadata Instructions', () => {
                 ['idempotent', getBooleanDecoder()],
                 ['key', getStringDecoder()],
             ]),
-            { idempotent: true, key: 'MyTestField' }
+            { idempotent: true, key: 'MyTestField' },
         );
     });
 
@@ -142,7 +142,7 @@ describe('Token Metadata Instructions', () => {
             }),
             splDiscriminate('spl_token_metadata_interface:update_the_authority'),
             getStructDecoder([['newAuthority', fixDecoderSize(getBytesDecoder(), 32)]]),
-            { newAuthority: Uint8Array.from(newAuthority.toBuffer()) }
+            { newAuthority: Uint8Array.from(newAuthority.toBuffer()) },
         );
     });
 
@@ -161,7 +161,7 @@ describe('Token Metadata Instructions', () => {
                 ['start', getOptionDecoder(getU64Decoder())],
                 ['end', getOptionDecoder(getU64Decoder())],
             ]),
-            { start, end }
+            { start, end },
         );
     });
 });

--- a/token/js/.prettierignore
+++ b/token/js/.prettierignore
@@ -1,5 +1,0 @@
-docs
-lib
-test-ledger
-
-package-lock.json

--- a/token/js/.prettierrc
+++ b/token/js/.prettierrc
@@ -1,7 +1,0 @@
-{
-    "printWidth": 120,
-    "trailingComma": "es5",
-    "tabWidth": 4,
-    "semi": true,
-    "singleQuote": true
-}

--- a/token/js/examples/cpiGuard.ts
+++ b/token/js/examples/cpiGuard.ts
@@ -35,7 +35,7 @@ import {
         decimals,
         undefined,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const accountLen = getAccountLen([ExtensionType.CpiGuard]);
@@ -53,7 +53,7 @@ import {
             programId: TOKEN_2022_PROGRAM_ID,
         }),
         createInitializeAccountInstruction(destination, mint, owner.publicKey, TOKEN_2022_PROGRAM_ID),
-        createEnableCpiGuardInstruction(destination, owner.publicKey, [], TOKEN_2022_PROGRAM_ID)
+        createEnableCpiGuardInstruction(destination, owner.publicKey, [], TOKEN_2022_PROGRAM_ID),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, owner, destinationKeypair], undefined);

--- a/token/js/examples/createMintAndTransferTokens.ts
+++ b/token/js/examples/createMintAndTransferTokens.ts
@@ -26,7 +26,7 @@ import { createMint, getOrCreateAssociatedTokenAccount, mintTo, transfer } from 
         connection,
         fromWallet,
         mint,
-        fromWallet.publicKey
+        fromWallet.publicKey,
     );
 
     // Get the token account of the toWallet address, and if it does not exist, create it
@@ -40,7 +40,7 @@ import { createMint, getOrCreateAssociatedTokenAccount, mintTo, transfer } from 
         fromTokenAccount.address,
         fromWallet.publicKey,
         1000000000,
-        []
+        [],
     );
     console.log('mint tx:', signature);
 
@@ -52,7 +52,7 @@ import { createMint, getOrCreateAssociatedTokenAccount, mintTo, transfer } from 
         toTokenAccount.address,
         fromWallet.publicKey,
         1000000000,
-        []
+        [],
     );
     console.log('transfer tx:', signature);
 })();

--- a/token/js/examples/createMintCloseAuthority.ts
+++ b/token/js/examples/createMintCloseAuthority.ts
@@ -48,8 +48,8 @@ import {
             9,
             mintAuthority.publicKey,
             freezeAuthority.publicKey,
-            TOKEN_2022_PROGRAM_ID
-        )
+            TOKEN_2022_PROGRAM_ID,
+        ),
     );
     await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
 

--- a/token/js/examples/defaultAccountState.ts
+++ b/token/js/examples/defaultAccountState.ts
@@ -51,8 +51,8 @@ import {
             decimals,
             mintAuthority.publicKey,
             freezeAuthority.publicKey,
-            TOKEN_2022_PROGRAM_ID
-        )
+            TOKEN_2022_PROGRAM_ID,
+        ),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
@@ -65,6 +65,6 @@ import {
         freezeAuthority,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 })();

--- a/token/js/examples/immutableOwner.ts
+++ b/token/js/examples/immutableOwner.ts
@@ -34,7 +34,7 @@ import {
         decimals,
         undefined,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const accountLen = getAccountLen([ExtensionType.ImmutableOwner]);
@@ -52,7 +52,7 @@ import {
             programId: TOKEN_2022_PROGRAM_ID,
         }),
         createInitializeImmutableOwnerInstruction(account, TOKEN_2022_PROGRAM_ID),
-        createInitializeAccountInstruction(account, mint, owner.publicKey, TOKEN_2022_PROGRAM_ID)
+        createInitializeAccountInstruction(account, mint, owner.publicKey, TOKEN_2022_PROGRAM_ID),
     );
     await sendAndConfirmTransaction(connection, transaction, [payer, accountKeypair], undefined);
 

--- a/token/js/examples/interestBearing.ts
+++ b/token/js/examples/interestBearing.ts
@@ -24,7 +24,7 @@ import { createInterestBearingMint, updateRateInterestBearingMint, TOKEN_2022_PR
         decimals,
         mintKeypair,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const updateRate = 50;
@@ -36,6 +36,6 @@ import { createInterestBearingMint, updateRateInterestBearingMint, TOKEN_2022_PR
         updateRate,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 })();

--- a/token/js/examples/memoTransfer.ts
+++ b/token/js/examples/memoTransfer.ts
@@ -39,7 +39,7 @@ import {
         decimals,
         undefined,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const accountLen = getAccountLen([ExtensionType.MemoTransfer]);
@@ -57,7 +57,7 @@ import {
             programId: TOKEN_2022_PROGRAM_ID,
         }),
         createInitializeAccountInstruction(destination, mint, owner.publicKey, TOKEN_2022_PROGRAM_ID),
-        createEnableRequiredMemoTransfersInstruction(destination, owner.publicKey, [], TOKEN_2022_PROGRAM_ID)
+        createEnableRequiredMemoTransfersInstruction(destination, owner.publicKey, [], TOKEN_2022_PROGRAM_ID),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, owner, destinationKeypair], undefined);
@@ -72,13 +72,13 @@ import {
         mint,
         payer.publicKey,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
     await mintTo(connection, payer, mint, sourceTokenAccount, mintAuthority, 100, [], undefined, TOKEN_2022_PROGRAM_ID);
 
     const transferTransaction = new Transaction().add(
         createMemoInstruction('Hello, memo-transfer!', [payer.publicKey]),
-        createTransferInstruction(sourceTokenAccount, destination, payer.publicKey, 100, [], TOKEN_2022_PROGRAM_ID)
+        createTransferInstruction(sourceTokenAccount, destination, payer.publicKey, 100, [], TOKEN_2022_PROGRAM_ID),
     );
     await sendAndConfirmTransaction(connection, transferTransaction, [payer], undefined);
 })();

--- a/token/js/examples/metadata.ts
+++ b/token/js/examples/metadata.ts
@@ -63,7 +63,7 @@ import {
             mint.publicKey,
             payer.publicKey,
             mint.publicKey,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         ),
         createInitializeMintInstruction(mint.publicKey, decimals, payer.publicKey, null, TOKEN_2022_PROGRAM_ID),
         createInitializeInstruction({
@@ -102,7 +102,7 @@ import {
             updateAuthority: payer.publicKey,
             key: 'new-field',
             idempotent: true, // If false the operation will fail if the field does not exist in the metadata
-        })
+        }),
     );
     const sig = await sendAndConfirmTransaction(connection, mintTransaction, [payer, mint]);
     console.log('Signature:', sig);

--- a/token/js/examples/nonTransferable.ts
+++ b/token/js/examples/nonTransferable.ts
@@ -39,7 +39,7 @@ import {
             programId: TOKEN_2022_PROGRAM_ID,
         }),
         createInitializeNonTransferableMintInstruction(mint, TOKEN_2022_PROGRAM_ID),
-        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID)
+        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID),
     );
     await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
 })();

--- a/token/js/examples/permanentDelegate.ts
+++ b/token/js/examples/permanentDelegate.ts
@@ -46,7 +46,7 @@ import {
             programId: TOKEN_2022_PROGRAM_ID,
         }),
         createInitializePermanentDelegateInstruction(mint, permanentDelegate.publicKey, TOKEN_2022_PROGRAM_ID),
-        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID)
+        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID),
     );
     await sendAndConfirmTransaction(connection, mintTransaction, [payer, mintKeypair], undefined);
 
@@ -59,7 +59,7 @@ import {
         owner.publicKey,
         undefined,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
     await mintTo(
         connection,
@@ -70,7 +70,7 @@ import {
         mintAmount,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const accountKeypair = Keypair.generate();
@@ -81,7 +81,7 @@ import {
         owner.publicKey,
         accountKeypair,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     // Transfer by signing with the permanent delegate
@@ -96,6 +96,6 @@ import {
         decimals,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 })();

--- a/token/js/examples/reallocate.ts
+++ b/token/js/examples/reallocate.ts
@@ -32,7 +32,7 @@ import {
         decimals,
         undefined,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const owner = Keypair.generate();
@@ -43,7 +43,7 @@ import {
         owner.publicKey,
         undefined,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const extensions = [ExtensionType.MemoTransfer];
@@ -54,9 +54,9 @@ import {
             extensions,
             owner.publicKey,
             undefined,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         ),
-        createEnableRequiredMemoTransfersInstruction(account, owner.publicKey, [], TOKEN_2022_PROGRAM_ID)
+        createEnableRequiredMemoTransfersInstruction(account, owner.publicKey, [], TOKEN_2022_PROGRAM_ID),
     );
     await sendAndConfirmTransaction(connection, transaction, [payer, owner], undefined);
 })();

--- a/token/js/examples/transferFee.ts
+++ b/token/js/examples/transferFee.ts
@@ -63,9 +63,9 @@ import {
             withdrawWithheldAuthority.publicKey,
             feeBasisPoints,
             maxFee,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         ),
-        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID)
+        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID),
     );
     await sendAndConfirmTransaction(connection, mintTransaction, [payer, mintKeypair], undefined);
 
@@ -78,7 +78,7 @@ import {
         owner.publicKey,
         undefined,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
     await mintTo(
         connection,
@@ -89,7 +89,7 @@ import {
         mintAmount,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const accountKeypair = Keypair.generate();
@@ -100,7 +100,7 @@ import {
         owner.publicKey,
         accountKeypair,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const transferAmount = BigInt(1_000_000);
@@ -117,7 +117,7 @@ import {
         fee,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const allAccounts = await connection.getProgramAccounts(TOKEN_2022_PROGRAM_ID, {
@@ -149,7 +149,7 @@ import {
         [],
         accountsToWithdrawFrom,
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     await harvestWithheldTokensToMint(connection, payer, mint, [destinationAccount], undefined, TOKEN_2022_PROGRAM_ID);
@@ -162,6 +162,6 @@ import {
         withdrawWithheldAuthority,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 })();

--- a/token/js/examples/transferHook.ts
+++ b/token/js/examples/transferHook.ts
@@ -52,7 +52,7 @@ import {
             programId: TOKEN_2022_PROGRAM_ID,
         }),
         createInitializeTransferHookInstruction(mint, payer.publicKey, transferHookPogramId, TOKEN_2022_PROGRAM_ID),
-        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID)
+        createInitializeMintInstruction(mint, decimals, mintAuthority.publicKey, null, TOKEN_2022_PROGRAM_ID),
     );
     await sendAndConfirmTransaction(connection, mintTransaction, [payer, mintKeypair], undefined);
 
@@ -64,7 +64,7 @@ import {
         payer.publicKey,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 
     const senderAta = getAssociatedTokenAddressSync(
@@ -72,14 +72,14 @@ import {
         sender.publicKey,
         false,
         TOKEN_2022_PROGRAM_ID,
-        ASSOCIATED_TOKEN_PROGRAM_ID
+        ASSOCIATED_TOKEN_PROGRAM_ID,
     );
     const recipientAta = getAssociatedTokenAddressSync(
         mint,
         recipient.publicKey,
         false,
         TOKEN_2022_PROGRAM_ID,
-        ASSOCIATED_TOKEN_PROGRAM_ID
+        ASSOCIATED_TOKEN_PROGRAM_ID,
     );
 
     await transferCheckedWithTransferHook(
@@ -93,6 +93,6 @@ import {
         9,
         [],
         undefined,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_2022_PROGRAM_ID,
     );
 })();

--- a/token/js/src/actions/amountToUiAmount.ts
+++ b/token/js/src/actions/amountToUiAmount.ts
@@ -19,7 +19,7 @@ export async function amountToUiAmount(
     payer: Signer,
     mint: PublicKey,
     amount: number | bigint,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<string | TransactionError | null> {
     const transaction = new Transaction().add(createAmountToUiAmountInstruction(mint, amount, programId));
     const { returnData, err } = (await connection.simulateTransaction(transaction, [payer], false)).value;

--- a/token/js/src/actions/approve.ts
+++ b/token/js/src/actions/approve.ts
@@ -28,12 +28,12 @@ export async function approve(
     amount: number | bigint,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createApproveInstruction(account, delegate, ownerPublicKey, amount, multiSigners, programId)
+        createApproveInstruction(account, delegate, ownerPublicKey, amount, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/approveChecked.ts
+++ b/token/js/src/actions/approveChecked.ts
@@ -33,7 +33,7 @@ export async function approveChecked(
     decimals: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
@@ -46,8 +46,8 @@ export async function approveChecked(
             amount,
             decimals,
             multiSigners,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/burn.ts
+++ b/token/js/src/actions/burn.ts
@@ -28,12 +28,12 @@ export async function burn(
     amount: number | bigint,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createBurnInstruction(account, mint, ownerPublicKey, amount, multiSigners, programId)
+        createBurnInstruction(account, mint, ownerPublicKey, amount, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/burnChecked.ts
+++ b/token/js/src/actions/burnChecked.ts
@@ -30,12 +30,12 @@ export async function burnChecked(
     decimals: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createBurnCheckedInstruction(account, mint, ownerPublicKey, amount, decimals, multiSigners, programId)
+        createBurnCheckedInstruction(account, mint, ownerPublicKey, amount, decimals, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/closeAccount.ts
+++ b/token/js/src/actions/closeAccount.ts
@@ -26,12 +26,12 @@ export async function closeAccount(
     authority: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
     const transaction = new Transaction().add(
-        createCloseAccountInstruction(account, destination, authorityPublicKey, multiSigners, programId)
+        createCloseAccountInstruction(account, destination, authorityPublicKey, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/createAccount.ts
+++ b/token/js/src/actions/createAccount.ts
@@ -26,7 +26,7 @@ export async function createAccount(
     owner: PublicKey,
     keypair?: Keypair,
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<PublicKey> {
     // If a keypair isn't provided, create the associated token account and return its address
     if (!keypair) return await createAssociatedTokenAccount(connection, payer, mint, owner, confirmOptions, programId);
@@ -44,7 +44,7 @@ export async function createAccount(
             lamports,
             programId,
         }),
-        createInitializeAccountInstruction(keypair.publicKey, mint, owner, programId)
+        createInitializeAccountInstruction(keypair.publicKey, mint, owner, programId),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, keypair], confirmOptions);

--- a/token/js/src/actions/createAssociatedTokenAccount.ts
+++ b/token/js/src/actions/createAssociatedTokenAccount.ts
@@ -24,7 +24,7 @@ export async function createAssociatedTokenAccount(
     owner: PublicKey,
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): Promise<PublicKey> {
     const associatedToken = getAssociatedTokenAddressSync(mint, owner, false, programId, associatedTokenProgramId);
 
@@ -35,8 +35,8 @@ export async function createAssociatedTokenAccount(
             owner,
             mint,
             programId,
-            associatedTokenProgramId
-        )
+            associatedTokenProgramId,
+        ),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);

--- a/token/js/src/actions/createAssociatedTokenAccountIdempotent.ts
+++ b/token/js/src/actions/createAssociatedTokenAccountIdempotent.ts
@@ -25,7 +25,7 @@ export async function createAssociatedTokenAccountIdempotent(
     owner: PublicKey,
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): Promise<PublicKey> {
     const associatedToken = getAssociatedTokenAddressSync(mint, owner, false, programId, associatedTokenProgramId);
 
@@ -36,8 +36,8 @@ export async function createAssociatedTokenAccountIdempotent(
             owner,
             mint,
             programId,
-            associatedTokenProgramId
-        )
+            associatedTokenProgramId,
+        ),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);

--- a/token/js/src/actions/createMint.ts
+++ b/token/js/src/actions/createMint.ts
@@ -26,7 +26,7 @@ export async function createMint(
     decimals: number,
     keypair = Keypair.generate(),
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<PublicKey> {
     const lamports = await getMinimumBalanceForRentExemptMint(connection);
 
@@ -38,7 +38,7 @@ export async function createMint(
             lamports,
             programId,
         }),
-        createInitializeMint2Instruction(keypair.publicKey, decimals, mintAuthority, freezeAuthority, programId)
+        createInitializeMint2Instruction(keypair.publicKey, decimals, mintAuthority, freezeAuthority, programId),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, keypair], confirmOptions);

--- a/token/js/src/actions/createMultisig.ts
+++ b/token/js/src/actions/createMultisig.ts
@@ -24,7 +24,7 @@ export async function createMultisig(
     m: number,
     keypair = Keypair.generate(),
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<PublicKey> {
     const lamports = await getMinimumBalanceForRentExemptMultisig(connection);
 
@@ -36,7 +36,7 @@ export async function createMultisig(
             lamports,
             programId,
         }),
-        createInitializeMultisigInstruction(keypair.publicKey, signers, m, programId)
+        createInitializeMultisigInstruction(keypair.publicKey, signers, m, programId),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, keypair], confirmOptions);

--- a/token/js/src/actions/createNativeMint.ts
+++ b/token/js/src/actions/createNativeMint.ts
@@ -17,10 +17,10 @@ export async function createNativeMint(
     payer: Signer,
     confirmOptions?: ConfirmOptions,
     nativeMint = NATIVE_MINT_2022,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<void> {
     const transaction = new Transaction().add(
-        createCreateNativeMintInstruction(payer.publicKey, nativeMint, programId)
+        createCreateNativeMintInstruction(payer.publicKey, nativeMint, programId),
     );
     await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);
 }

--- a/token/js/src/actions/createWrappedNativeAccount.ts
+++ b/token/js/src/actions/createWrappedNativeAccount.ts
@@ -29,7 +29,7 @@ export async function createWrappedNativeAccount(
     keypair?: Keypair,
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
-    nativeMint = NATIVE_MINT
+    nativeMint = NATIVE_MINT,
 ): Promise<PublicKey> {
     // If the amount provided is explicitly 0 or NaN, just create the account without funding it
     if (!amount) return await createAccount(connection, payer, nativeMint, owner, keypair, confirmOptions, programId);
@@ -41,7 +41,7 @@ export async function createWrappedNativeAccount(
             owner,
             false,
             programId,
-            ASSOCIATED_TOKEN_PROGRAM_ID
+            ASSOCIATED_TOKEN_PROGRAM_ID,
         );
 
         const transaction = new Transaction().add(
@@ -51,14 +51,14 @@ export async function createWrappedNativeAccount(
                 owner,
                 nativeMint,
                 programId,
-                ASSOCIATED_TOKEN_PROGRAM_ID
+                ASSOCIATED_TOKEN_PROGRAM_ID,
             ),
             SystemProgram.transfer({
                 fromPubkey: payer.publicKey,
                 toPubkey: associatedToken,
                 lamports: amount,
             }),
-            createSyncNativeInstruction(associatedToken, programId)
+            createSyncNativeInstruction(associatedToken, programId),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);
@@ -82,7 +82,7 @@ export async function createWrappedNativeAccount(
             toPubkey: keypair.publicKey,
             lamports: amount,
         }),
-        createInitializeAccountInstruction(keypair.publicKey, nativeMint, owner, programId)
+        createInitializeAccountInstruction(keypair.publicKey, nativeMint, owner, programId),
     );
 
     await sendAndConfirmTransaction(connection, transaction, [payer, keypair], confirmOptions);

--- a/token/js/src/actions/freezeAccount.ts
+++ b/token/js/src/actions/freezeAccount.ts
@@ -26,12 +26,12 @@ export async function freezeAccount(
     authority: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
     const transaction = new Transaction().add(
-        createFreezeAccountInstruction(account, mint, authorityPublicKey, multiSigners, programId)
+        createFreezeAccountInstruction(account, mint, authorityPublicKey, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/getOrCreateAssociatedTokenAccount.ts
+++ b/token/js/src/actions/getOrCreateAssociatedTokenAccount.ts
@@ -36,14 +36,14 @@ export async function getOrCreateAssociatedTokenAccount(
     commitment?: Commitment,
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): Promise<Account> {
     const associatedToken = getAssociatedTokenAddressSync(
         mint,
         owner,
         allowOwnerOffCurve,
         programId,
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 
     // This is the optimal logic, considering TX fee, client-side computation, RPC roundtrips and guaranteed idempotent.
@@ -65,8 +65,8 @@ export async function getOrCreateAssociatedTokenAccount(
                         owner,
                         mint,
                         programId,
-                        associatedTokenProgramId
-                    )
+                        associatedTokenProgramId,
+                    ),
                 );
 
                 await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);

--- a/token/js/src/actions/mintTo.ts
+++ b/token/js/src/actions/mintTo.ts
@@ -28,12 +28,12 @@ export async function mintTo(
     amount: number | bigint,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
     const transaction = new Transaction().add(
-        createMintToInstruction(mint, destination, authorityPublicKey, amount, multiSigners, programId)
+        createMintToInstruction(mint, destination, authorityPublicKey, amount, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/mintToChecked.ts
+++ b/token/js/src/actions/mintToChecked.ts
@@ -30,12 +30,20 @@ export async function mintToChecked(
     decimals: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
     const transaction = new Transaction().add(
-        createMintToCheckedInstruction(mint, destination, authorityPublicKey, amount, decimals, multiSigners, programId)
+        createMintToCheckedInstruction(
+            mint,
+            destination,
+            authorityPublicKey,
+            amount,
+            decimals,
+            multiSigners,
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/recoverNested.ts
+++ b/token/js/src/actions/recoverNested.ts
@@ -26,14 +26,14 @@ export async function recoverNested(
     nestedMint: PublicKey,
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const ownerAssociatedToken = getAssociatedTokenAddressSync(
         mint,
         owner.publicKey,
         false,
         programId,
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 
     const destinationAssociatedToken = getAssociatedTokenAddressSync(
@@ -41,7 +41,7 @@ export async function recoverNested(
         owner.publicKey,
         false,
         programId,
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 
     const nestedAssociatedToken = getAssociatedTokenAddressSync(
@@ -49,7 +49,7 @@ export async function recoverNested(
         ownerAssociatedToken,
         true,
         programId,
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 
     const transaction = new Transaction().add(
@@ -61,8 +61,8 @@ export async function recoverNested(
             mint,
             owner.publicKey,
             programId,
-            associatedTokenProgramId
-        )
+            associatedTokenProgramId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, owner], confirmOptions);

--- a/token/js/src/actions/revoke.ts
+++ b/token/js/src/actions/revoke.ts
@@ -24,12 +24,12 @@ export async function revoke(
     owner: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createRevokeInstruction(account, ownerPublicKey, multiSigners, programId)
+        createRevokeInstruction(account, ownerPublicKey, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/setAuthority.ts
+++ b/token/js/src/actions/setAuthority.ts
@@ -29,7 +29,7 @@ export async function setAuthority(
     newAuthority: PublicKey | null,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [currentAuthorityPublicKey, signers] = getSigners(currentAuthority, multiSigners);
 
@@ -40,8 +40,8 @@ export async function setAuthority(
             authorityType,
             newAuthority,
             multiSigners,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/syncNative.ts
+++ b/token/js/src/actions/syncNative.ts
@@ -19,7 +19,7 @@ export async function syncNative(
     payer: Signer,
     account: PublicKey,
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const transaction = new Transaction().add(createSyncNativeInstruction(account, programId));
 

--- a/token/js/src/actions/thawAccount.ts
+++ b/token/js/src/actions/thawAccount.ts
@@ -26,12 +26,12 @@ export async function thawAccount(
     authority: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
     const transaction = new Transaction().add(
-        createThawAccountInstruction(account, mint, authorityPublicKey, multiSigners, programId)
+        createThawAccountInstruction(account, mint, authorityPublicKey, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/transfer.ts
+++ b/token/js/src/actions/transfer.ts
@@ -28,12 +28,12 @@ export async function transfer(
     amount: number | bigint,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createTransferInstruction(source, destination, ownerPublicKey, amount, multiSigners, programId)
+        createTransferInstruction(source, destination, ownerPublicKey, amount, multiSigners, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/transferChecked.ts
+++ b/token/js/src/actions/transferChecked.ts
@@ -32,7 +32,7 @@ export async function transferChecked(
     decimals: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
@@ -45,8 +45,8 @@ export async function transferChecked(
             amount,
             decimals,
             multiSigners,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/actions/uiAmountToAmount.ts
+++ b/token/js/src/actions/uiAmountToAmount.ts
@@ -20,7 +20,7 @@ export async function uiAmountToAmount(
     payer: Signer,
     mint: PublicKey,
     amount: string,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<bigint | TransactionError | null> {
     const transaction = new Transaction().add(createUiAmountToAmountInstruction(mint, amount, programId));
     const { returnData, err } = (await connection.simulateTransaction(transaction, [payer], false)).value;

--- a/token/js/src/extensions/cpiGuard/actions.ts
+++ b/token/js/src/extensions/cpiGuard/actions.ts
@@ -24,12 +24,12 @@ export async function enableCpiGuard(
     owner: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createEnableCpiGuardInstruction(account, ownerPublicKey, signers, programId)
+        createEnableCpiGuardInstruction(account, ownerPublicKey, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -55,12 +55,12 @@ export async function disableCpiGuard(
     owner: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createDisableCpiGuardInstruction(account, ownerPublicKey, signers, programId)
+        createDisableCpiGuardInstruction(account, ownerPublicKey, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/extensions/cpiGuard/instructions.ts
+++ b/token/js/src/extensions/cpiGuard/instructions.ts
@@ -34,7 +34,7 @@ export function createEnableCpiGuardInstruction(
     account: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     return createCpiGuardInstruction(CpiGuardInstruction.Enable, account, authority, multiSigners, programId);
 }
@@ -53,7 +53,7 @@ export function createDisableCpiGuardInstruction(
     account: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     return createCpiGuardInstruction(CpiGuardInstruction.Disable, account, authority, multiSigners, programId);
 }
@@ -63,7 +63,7 @@ function createCpiGuardInstruction(
     account: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[],
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -76,7 +76,7 @@ function createCpiGuardInstruction(
             instruction: TokenInstruction.CpiGuardExtension,
             cpiGuardInstruction,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });

--- a/token/js/src/extensions/defaultAccountState/actions.ts
+++ b/token/js/src/extensions/defaultAccountState/actions.ts
@@ -26,7 +26,7 @@ export async function initializeDefaultAccountState(
     mint: PublicKey,
     state: AccountState,
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const transaction = new Transaction().add(createInitializeDefaultAccountStateInstruction(mint, state, programId));
 
@@ -55,12 +55,12 @@ export async function updateDefaultAccountState(
     freezeAuthority: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [freezeAuthorityPublicKey, signers] = getSigners(freezeAuthority, multiSigners);
 
     const transaction = new Transaction().add(
-        createUpdateDefaultAccountStateInstruction(mint, state, freezeAuthorityPublicKey, signers, programId)
+        createUpdateDefaultAccountStateInstruction(mint, state, freezeAuthorityPublicKey, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/extensions/defaultAccountState/instructions.ts
+++ b/token/js/src/extensions/defaultAccountState/instructions.ts
@@ -38,7 +38,7 @@ export const defaultAccountStateInstructionData = struct<DefaultAccountStateInst
 export function createInitializeDefaultAccountStateInstruction(
     mint: PublicKey,
     accountState: AccountState,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -51,7 +51,7 @@ export function createInitializeDefaultAccountStateInstruction(
             defaultAccountStateInstruction: DefaultAccountStateInstruction.Initialize,
             accountState,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -73,7 +73,7 @@ export function createUpdateDefaultAccountStateInstruction(
     accountState: AccountState,
     freezeAuthority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -87,7 +87,7 @@ export function createUpdateDefaultAccountStateInstruction(
             defaultAccountStateInstruction: DefaultAccountStateInstruction.Update,
             accountState,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });

--- a/token/js/src/extensions/extensionType.ts
+++ b/token/js/src/extensions/extensionType.ts
@@ -215,7 +215,7 @@ export function getAccountTypeOfMintType(e: ExtensionType): ExtensionType {
 function getLen(
     extensionTypes: ExtensionType[],
     baseSize: number,
-    variableLengthExtensions: { [E in ExtensionType]?: number } = {}
+    variableLengthExtensions: { [E in ExtensionType]?: number } = {},
 ): number {
     if (extensionTypes.length === 0 && Object.keys(variableLengthExtensions).length === 0) {
         return baseSize;
@@ -225,7 +225,7 @@ function getLen(
             ACCOUNT_TYPE_SIZE +
             extensionTypes
                 .filter((element, i) => i === extensionTypes.indexOf(element))
-                .map((element) => addTypeAndLengthToLen(getTypeLen(element)))
+                .map(element => addTypeAndLengthToLen(getTypeLen(element)))
                 .reduce((a, b) => a + b, 0) +
             Object.entries(variableLengthExtensions)
                 .map(([extension, len]) => {
@@ -245,7 +245,7 @@ function getLen(
 
 export function getMintLen(
     extensionTypes: ExtensionType[],
-    variableLengthExtensions: { [E in ExtensionType]?: number } = {}
+    variableLengthExtensions: { [E in ExtensionType]?: number } = {},
 ): number {
     return getLen(extensionTypes, MINT_SIZE, variableLengthExtensions);
 }
@@ -292,7 +292,7 @@ export function getNewAccountLenForExtensionLen(
     address: PublicKey,
     extensionType: ExtensionType,
     extensionLen: number,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): number {
     const mint = unpackMint(address, info, programId);
     const extensionData = getExtensionData(extensionType, mint.tlvData);

--- a/token/js/src/extensions/groupMemberPointer/instructions.ts
+++ b/token/js/src/extensions/groupMemberPointer/instructions.ts
@@ -39,7 +39,7 @@ export function createInitializeGroupMemberPointerInstruction(
     mint: PublicKey,
     authority: PublicKey | null,
     memberAddress: PublicKey | null,
-    programId: PublicKey = TOKEN_2022_PROGRAM_ID
+    programId: PublicKey = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -54,7 +54,7 @@ export function createInitializeGroupMemberPointerInstruction(
             authority: authority ?? PublicKey.default,
             memberAddress: memberAddress ?? PublicKey.default,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data: data });
@@ -76,7 +76,7 @@ export function createUpdateGroupMemberPointerInstruction(
     authority: PublicKey,
     memberAddress: PublicKey | null,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId: PublicKey = TOKEN_2022_PROGRAM_ID
+    programId: PublicKey = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -91,7 +91,7 @@ export function createUpdateGroupMemberPointerInstruction(
             groupMemberPointerInstruction: GroupMemberPointerInstruction.Update,
             memberAddress: memberAddress ?? PublicKey.default,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data: data });

--- a/token/js/src/extensions/groupPointer/instructions.ts
+++ b/token/js/src/extensions/groupPointer/instructions.ts
@@ -39,7 +39,7 @@ export function createInitializeGroupPointerInstruction(
     mint: PublicKey,
     authority: PublicKey | null,
     groupAddress: PublicKey | null,
-    programId: PublicKey = TOKEN_2022_PROGRAM_ID
+    programId: PublicKey = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -54,7 +54,7 @@ export function createInitializeGroupPointerInstruction(
             authority: authority ?? PublicKey.default,
             groupAddress: groupAddress ?? PublicKey.default,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data: data });
@@ -76,7 +76,7 @@ export function createUpdateGroupPointerInstruction(
     authority: PublicKey,
     groupAddress: PublicKey | null,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId: PublicKey = TOKEN_2022_PROGRAM_ID
+    programId: PublicKey = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -91,7 +91,7 @@ export function createUpdateGroupPointerInstruction(
             groupPointerInstruction: GroupPointerInstruction.Update,
             groupAddress: groupAddress ?? PublicKey.default,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data: data });

--- a/token/js/src/extensions/interestBearingMint/actions.ts
+++ b/token/js/src/extensions/interestBearingMint/actions.ts
@@ -35,7 +35,7 @@ export async function createInterestBearingMint(
     decimals: number,
     keypair = Keypair.generate(),
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<PublicKey> {
     const mintLen = getMintLen([ExtensionType.InterestBearingConfig]);
     const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
@@ -48,7 +48,7 @@ export async function createInterestBearingMint(
             programId,
         }),
         createInitializeInterestBearingMintInstruction(keypair.publicKey, rateAuthority, rate, programId),
-        createInitializeMintInstruction(keypair.publicKey, decimals, mintAuthority, freezeAuthority, programId)
+        createInitializeMintInstruction(keypair.publicKey, decimals, mintAuthority, freezeAuthority, programId),
     );
     await sendAndConfirmTransaction(connection, transaction, [payer, keypair], confirmOptions);
     return keypair.publicKey;
@@ -76,11 +76,11 @@ export async function updateRateInterestBearingMint(
     rate: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<string> {
     const [rateAuthorityPublicKey, signers] = getSigners(rateAuthority, multiSigners);
     const transaction = new Transaction().add(
-        createUpdateRateInterestBearingMintInstruction(mint, rateAuthorityPublicKey, rate, signers, programId)
+        createUpdateRateInterestBearingMintInstruction(mint, rateAuthorityPublicKey, rate, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, rateAuthority, ...signers], confirmOptions);

--- a/token/js/src/extensions/interestBearingMint/instructions.ts
+++ b/token/js/src/extensions/interestBearingMint/instructions.ts
@@ -52,7 +52,7 @@ export function createInitializeInterestBearingMintInstruction(
     mint: PublicKey,
     rateAuthority: PublicKey,
     rate: number,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ) {
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
     const data = Buffer.alloc(interestBearingMintInitializeInstructionData.span);
@@ -63,7 +63,7 @@ export function createInitializeInterestBearingMintInstruction(
             rateAuthority,
             rate,
         },
-        data
+        data,
     );
     return new TransactionInstruction({ keys, programId, data });
 }
@@ -84,7 +84,7 @@ export function createUpdateRateInterestBearingMintInstruction(
     rateAuthority: PublicKey,
     rate: number,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ) {
     const keys = addSigners(
         [
@@ -92,7 +92,7 @@ export function createUpdateRateInterestBearingMintInstruction(
             { pubkey: rateAuthority, isSigner: !multiSigners.length, isWritable: false },
         ],
         rateAuthority,
-        multiSigners
+        multiSigners,
     );
     const data = Buffer.alloc(interestBearingMintUpdateRateInstructionData.span);
     interestBearingMintUpdateRateInstructionData.encode(
@@ -101,7 +101,7 @@ export function createUpdateRateInterestBearingMintInstruction(
             interestBearingMintInstruction: InterestBearingMintInstruction.UpdateRate,
             rate,
         },
-        data
+        data,
     );
     return new TransactionInstruction({ keys, programId, data });
 }

--- a/token/js/src/extensions/memoTransfer/actions.ts
+++ b/token/js/src/extensions/memoTransfer/actions.ts
@@ -27,12 +27,12 @@ export async function enableRequiredMemoTransfers(
     owner: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createEnableRequiredMemoTransfersInstruction(account, ownerPublicKey, signers, programId)
+        createEnableRequiredMemoTransfersInstruction(account, ownerPublicKey, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -58,12 +58,12 @@ export async function disableRequiredMemoTransfers(
     owner: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
     const transaction = new Transaction().add(
-        createDisableRequiredMemoTransfersInstruction(account, ownerPublicKey, signers, programId)
+        createDisableRequiredMemoTransfersInstruction(account, ownerPublicKey, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/extensions/memoTransfer/instructions.ts
+++ b/token/js/src/extensions/memoTransfer/instructions.ts
@@ -37,7 +37,7 @@ export function createEnableRequiredMemoTransfersInstruction(
     account: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     return createMemoTransferInstruction(MemoTransferInstruction.Enable, account, authority, multiSigners, programId);
 }
@@ -56,7 +56,7 @@ export function createDisableRequiredMemoTransfersInstruction(
     account: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     return createMemoTransferInstruction(MemoTransferInstruction.Disable, account, authority, multiSigners, programId);
 }
@@ -66,7 +66,7 @@ function createMemoTransferInstruction(
     account: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[],
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -79,7 +79,7 @@ function createMemoTransferInstruction(
             instruction: TokenInstruction.MemoTransferExtension,
             memoTransferInstruction,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });

--- a/token/js/src/extensions/metadataPointer/instructions.ts
+++ b/token/js/src/extensions/metadataPointer/instructions.ts
@@ -39,7 +39,7 @@ export function createInitializeMetadataPointerInstruction(
     mint: PublicKey,
     authority: PublicKey | null,
     metadataAddress: PublicKey | null,
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -54,7 +54,7 @@ export function createInitializeMetadataPointerInstruction(
             authority: authority ?? PublicKey.default,
             metadataAddress: metadataAddress ?? PublicKey.default,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data: data });
@@ -76,7 +76,7 @@ export function createUpdateMetadataPointerInstruction(
     authority: PublicKey,
     metadataAddress: PublicKey | null,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId: PublicKey = TOKEN_2022_PROGRAM_ID
+    programId: PublicKey = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -91,7 +91,7 @@ export function createUpdateMetadataPointerInstruction(
             metadataPointerInstruction: MetadataPointerInstruction.Update,
             metadataAddress: metadataAddress ?? PublicKey.default,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data: data });

--- a/token/js/src/extensions/tokenGroup/actions.ts
+++ b/token/js/src/extensions/tokenGroup/actions.ts
@@ -38,7 +38,7 @@ export async function tokenGroupInitializeGroup(
     maxSize: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
 
@@ -50,7 +50,7 @@ export async function tokenGroupInitializeGroup(
             mintAuthority: mintAuthorityPublicKey,
             updateAuthority,
             maxSize,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -82,7 +82,7 @@ export async function tokenGroupInitializeGroupWithRentTransfer(
     maxSize: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
 
@@ -101,7 +101,7 @@ export async function tokenGroupInitializeGroupWithRentTransfer(
             mintAuthority: mintAuthorityPublicKey,
             updateAuthority,
             maxSize,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -129,7 +129,7 @@ export async function tokenGroupUpdateGroupMaxSize(
     maxSize: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
 
@@ -139,7 +139,7 @@ export async function tokenGroupUpdateGroupMaxSize(
             group: mint,
             updateAuthority: updateAuthorityPublicKey,
             maxSize,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -167,7 +167,7 @@ export async function tokenGroupUpdateGroupAuthority(
     newAuthority: PublicKey | null,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
 
@@ -177,7 +177,7 @@ export async function tokenGroupUpdateGroupAuthority(
             group: mint,
             currentAuthority: updateAuthorityPublicKey,
             newAuthority,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -210,7 +210,7 @@ export async function tokenGroupMemberInitialize(
     groupUpdateAuthority: PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
 
@@ -222,7 +222,7 @@ export async function tokenGroupMemberInitialize(
             memberMintAuthority: mintAuthorityPublicKey,
             group,
             groupUpdateAuthority,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -255,7 +255,7 @@ export async function tokenGroupMemberInitializeWithRentTransfer(
     groupUpdateAuthority: PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
 
@@ -274,7 +274,7 @@ export async function tokenGroupMemberInitializeWithRentTransfer(
             memberMintAuthority: mintAuthorityPublicKey,
             group,
             groupUpdateAuthority,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/extensions/tokenMetadata/actions.ts
+++ b/token/js/src/extensions/tokenMetadata/actions.ts
@@ -21,7 +21,7 @@ async function getAdditionalRentForNewMetadata(
     connection: Connection,
     address: PublicKey,
     tokenMetadata: TokenMetadata,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<number> {
     const info = await connection.getAccountInfo(address);
     if (!info) {
@@ -34,7 +34,7 @@ async function getAdditionalRentForNewMetadata(
         address,
         ExtensionType.TokenMetadata,
         extensionLen,
-        programId
+        programId,
     );
 
     if (newAccountLen <= info.data.length) {
@@ -51,7 +51,7 @@ async function getAdditionalRentForUpdatedMetadata(
     address: PublicKey,
     field: string | Field,
     value: string,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<number> {
     const info = await connection.getAccountInfo(address);
     if (!info) {
@@ -72,7 +72,7 @@ async function getAdditionalRentForUpdatedMetadata(
         address,
         ExtensionType.TokenMetadata,
         extensionLen,
-        programId
+        programId,
     );
 
     if (newAccountLen <= info.data.length) {
@@ -112,7 +112,7 @@ export async function tokenMetadataInitialize(
     uri: string,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
 
@@ -126,7 +126,7 @@ export async function tokenMetadataInitialize(
             name,
             symbol,
             uri,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -161,7 +161,7 @@ export async function tokenMetadataInitializeWithRentTransfer(
     uri: string,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [mintAuthorityPublicKey, signers] = getSigners(mintAuthority, multiSigners);
 
@@ -178,7 +178,7 @@ export async function tokenMetadataInitializeWithRentTransfer(
             uri,
             additionalMetadata: [],
         },
-        programId
+        programId,
     );
 
     if (lamports > 0) {
@@ -195,7 +195,7 @@ export async function tokenMetadataInitializeWithRentTransfer(
             name,
             symbol,
             uri,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -229,7 +229,7 @@ export async function tokenMetadataUpdateField(
     value: string,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
 
@@ -240,7 +240,7 @@ export async function tokenMetadataUpdateField(
             updateAuthority: updateAuthorityPublicKey,
             field,
             value,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -275,7 +275,7 @@ export async function tokenMetadataUpdateFieldWithRentTransfer(
     value: string,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
 
@@ -294,7 +294,7 @@ export async function tokenMetadataUpdateFieldWithRentTransfer(
             updateAuthority: updateAuthorityPublicKey,
             field,
             value,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -326,7 +326,7 @@ export async function tokenMetadataRemoveKey(
     idempotent: boolean,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
 
@@ -337,7 +337,7 @@ export async function tokenMetadataRemoveKey(
             updateAuthority: updateAuthorityPublicKey,
             key,
             idempotent,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -365,7 +365,7 @@ export async function tokenMetadataUpdateAuthority(
     newAuthority: PublicKey | null,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [updateAuthorityPublicKey, signers] = getSigners(updateAuthority, multiSigners);
 
@@ -375,7 +375,7 @@ export async function tokenMetadataUpdateAuthority(
             metadata: mint,
             oldAuthority: updateAuthorityPublicKey,
             newAuthority,
-        })
+        }),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/extensions/tokenMetadata/state.ts
+++ b/token/js/src/extensions/tokenMetadata/state.ts
@@ -41,7 +41,7 @@ export function updateTokenMetadata(current: TokenMetadata, key: Field | string,
     // Avoid mutating input, make a shallow copy
     const additionalMetadata = [...current.additionalMetadata];
 
-    const i = current.additionalMetadata.findIndex((x) => x[0] === field);
+    const i = current.additionalMetadata.findIndex(x => x[0] === field);
 
     if (i === -1) {
         // Key was not found, add it
@@ -71,7 +71,7 @@ export async function getTokenMetadata(
     connection: Connection,
     address: PublicKey,
     commitment?: Commitment,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TokenMetadata | null> {
     const mintInfo = await getMint(connection, address, commitment, programId);
     const data = getExtensionData(ExtensionType.TokenMetadata, mintInfo.tlvData);

--- a/token/js/src/extensions/transferFee/actions.ts
+++ b/token/js/src/extensions/transferFee/actions.ts
@@ -39,7 +39,7 @@ export async function transferCheckedWithFee(
     fee: bigint,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [ownerPublicKey, signers] = getSigners(owner, multiSigners);
 
@@ -53,8 +53,8 @@ export async function transferCheckedWithFee(
             decimals,
             fee,
             multiSigners,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -82,12 +82,12 @@ export async function withdrawWithheldTokensFromMint(
     authority: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
     const transaction = new Transaction().add(
-        createWithdrawWithheldTokensFromMintInstruction(mint, destination, authorityPublicKey, signers, programId)
+        createWithdrawWithheldTokensFromMintInstruction(mint, destination, authorityPublicKey, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -117,7 +117,7 @@ export async function withdrawWithheldTokensFromAccounts(
     multiSigners: Signer[],
     sources: PublicKey[],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
@@ -128,8 +128,8 @@ export async function withdrawWithheldTokensFromAccounts(
             authorityPublicKey,
             signers,
             sources,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -153,7 +153,7 @@ export async function harvestWithheldTokensToMint(
     mint: PublicKey,
     sources: PublicKey[],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const transaction = new Transaction().add(createHarvestWithheldTokensToMintInstruction(mint, sources, programId));
 
@@ -184,7 +184,7 @@ export async function setTransferFee(
     transferFeeBasisPoints: number,
     maximumFee: bigint,
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
@@ -195,8 +195,8 @@ export async function setTransferFee(
             signers,
             transferFeeBasisPoints,
             maximumFee,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/extensions/transferFee/instructions.ts
+++ b/token/js/src/extensions/transferFee/instructions.ts
@@ -63,7 +63,7 @@ export function createInitializeTransferFeeConfigInstruction(
     withdrawWithheldAuthority: PublicKey | null,
     transferFeeBasisPoints: number,
     maximumFee: bigint,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -80,7 +80,7 @@ export function createInitializeTransferFeeConfigInstruction(
             transferFeeBasisPoints: transferFeeBasisPoints,
             maximumFee: maximumFee,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -112,7 +112,7 @@ export interface DecodedInitializeTransferFeeConfigInstruction {
  */
 export function decodeInitializeTransferFeeConfigInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedInitializeTransferFeeConfigInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeTransferFeeConfigInstructionData.span)
@@ -232,7 +232,7 @@ export function createTransferCheckedWithFeeInstruction(
     decimals: number,
     fee: bigint,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -246,7 +246,7 @@ export function createTransferCheckedWithFeeInstruction(
             decimals,
             fee,
         },
-        data
+        data,
     );
     const keys = addSigners(
         [
@@ -255,7 +255,7 @@ export function createTransferCheckedWithFeeInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         authority,
-        multiSigners
+        multiSigners,
     );
     return new TransactionInstruction({ keys, programId, data });
 }
@@ -289,7 +289,7 @@ export interface DecodedTransferCheckedWithFeeInstruction {
  */
 export function decodeTransferCheckedWithFeeInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedTransferCheckedWithFeeInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== transferCheckedWithFeeInstructionData.span)
@@ -399,7 +399,7 @@ export function createWithdrawWithheldTokensFromMintInstruction(
     destination: PublicKey,
     authority: PublicKey,
     signers: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -410,7 +410,7 @@ export function createWithdrawWithheldTokensFromMintInstruction(
             instruction: TokenInstruction.TransferFeeExtension,
             transferFeeInstruction: TransferFeeInstruction.WithdrawWithheldTokensFromMint,
         },
-        data
+        data,
     );
     const keys = addSigners(
         [
@@ -418,7 +418,7 @@ export function createWithdrawWithheldTokensFromMintInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         authority,
-        signers
+        signers,
     );
     return new TransactionInstruction({ keys, programId, data });
 }
@@ -448,7 +448,7 @@ export interface DecodedWithdrawWithheldTokensFromMintInstruction {
  */
 export function decodeWithdrawWithheldTokensFromMintInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedWithdrawWithheldTokensFromMintInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== withdrawWithheldTokensFromMintInstructionData.span)
@@ -553,7 +553,7 @@ export function createWithdrawWithheldTokensFromAccountsInstruction(
     authority: PublicKey,
     signers: (Signer | PublicKey)[],
     sources: PublicKey[],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -565,7 +565,7 @@ export function createWithdrawWithheldTokensFromAccountsInstruction(
             transferFeeInstruction: TransferFeeInstruction.WithdrawWithheldTokensFromAccounts,
             numTokenAccounts: sources.length,
         },
-        data
+        data,
     );
     const keys = addSigners(
         [
@@ -573,7 +573,7 @@ export function createWithdrawWithheldTokensFromAccountsInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         authority,
-        signers
+        signers,
     );
     for (const source of sources) {
         keys.push({ pubkey: source, isSigner: false, isWritable: true });
@@ -608,7 +608,7 @@ export interface DecodedWithdrawWithheldTokensFromAccountsInstruction {
  */
 export function decodeWithdrawWithheldTokensFromAccountsInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedWithdrawWithheldTokensFromAccountsInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== withdrawWithheldTokensFromAccountsInstructionData.span)
@@ -717,7 +717,7 @@ export const harvestWithheldTokensToMintInstructionData = struct<HarvestWithheld
 export function createHarvestWithheldTokensToMintInstruction(
     mint: PublicKey,
     sources: PublicKey[],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -728,7 +728,7 @@ export function createHarvestWithheldTokensToMintInstruction(
             instruction: TokenInstruction.TransferFeeExtension,
             transferFeeInstruction: TransferFeeInstruction.HarvestWithheldTokensToMint,
         },
-        data
+        data,
     );
     const keys: AccountMeta[] = [];
     keys.push({ pubkey: mint, isSigner: false, isWritable: true });
@@ -761,7 +761,7 @@ export interface DecodedHarvestWithheldTokensToMintInstruction {
  */
 export function decodeHarvestWithheldTokensToMintInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedHarvestWithheldTokensToMintInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== harvestWithheldTokensToMintInstructionData.span)
@@ -861,7 +861,7 @@ export function createSetTransferFeeInstruction(
     signers: (Signer | PublicKey)[],
     transferFeeBasisPoints: number,
     maximumFee: bigint,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -875,7 +875,7 @@ export function createSetTransferFeeInstruction(
             transferFeeBasisPoints: transferFeeBasisPoints,
             maximumFee: maximumFee,
         },
-        data
+        data,
     );
     const keys = addSigners([{ pubkey: mint, isSigner: false, isWritable: true }], authority, signers);
 
@@ -908,7 +908,7 @@ export interface DecodedSetTransferFeeInstruction {
  */
 export function decodeSetTransferFeeInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedSetTransferFeeInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== setTransferFeeInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/extensions/transferHook/actions.ts
+++ b/token/js/src/extensions/transferHook/actions.ts
@@ -30,10 +30,10 @@ export async function initializeTransferHook(
     authority: PublicKey,
     transferHookProgramId: PublicKey,
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const transaction = new Transaction().add(
-        createInitializeTransferHookInstruction(mint, authority, transferHookProgramId, programId)
+        createInitializeTransferHookInstruction(mint, authority, transferHookProgramId, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer], confirmOptions);
@@ -61,12 +61,12 @@ export async function updateTransferHook(
     authority: Signer | PublicKey,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
     const transaction = new Transaction().add(
-        createUpdateTransferHookInstruction(mint, authorityPublicKey, transferHookProgramId, signers, programId)
+        createUpdateTransferHookInstruction(mint, authorityPublicKey, transferHookProgramId, signers, programId),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -100,7 +100,7 @@ export async function transferCheckedWithTransferHook(
     decimals: number,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
@@ -115,8 +115,8 @@ export async function transferCheckedWithTransferHook(
             decimals,
             signers,
             confirmOptions?.commitment,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);
@@ -152,7 +152,7 @@ export async function transferCheckedWithFeeAndTransferHook(
     fee: bigint,
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
@@ -168,8 +168,8 @@ export async function transferCheckedWithFeeAndTransferHook(
             fee,
             signers,
             confirmOptions?.commitment,
-            programId
-        )
+            programId,
+        ),
     );
 
     return await sendAndConfirmTransaction(connection, transaction, [payer, ...signers], confirmOptions);

--- a/token/js/src/extensions/transferHook/instructions.ts
+++ b/token/js/src/extensions/transferHook/instructions.ts
@@ -46,7 +46,7 @@ export function createInitializeTransferHookInstruction(
     mint: PublicKey,
     authority: PublicKey,
     transferHookProgramId: PublicKey,
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -61,7 +61,7 @@ export function createInitializeTransferHookInstruction(
             authority,
             transferHookProgramId,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -97,7 +97,7 @@ export function createUpdateTransferHookInstruction(
     authority: PublicKey,
     transferHookProgramId: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -111,7 +111,7 @@ export function createUpdateTransferHookInstruction(
             transferHookInstruction: TransferHookInstruction.Update,
             transferHookProgramId,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -119,7 +119,7 @@ export function createUpdateTransferHookInstruction(
 
 function deEscalateAccountMeta(accountMeta: AccountMeta, accountMetas: AccountMeta[]): AccountMeta {
     const maybeHighestPrivileges = accountMetas
-        .filter((x) => x.pubkey.equals(accountMeta.pubkey))
+        .filter(x => x.pubkey.equals(accountMeta.pubkey))
         .reduce<{ isSigner: boolean; isWritable: boolean } | undefined>((acc, x) => {
             if (!acc) return { isSigner: x.isSigner, isWritable: x.isWritable };
             return { isSigner: acc.isSigner || x.isSigner, isWritable: acc.isWritable || x.isWritable };
@@ -156,9 +156,9 @@ export function createExecuteInstruction(
     destination: PublicKey,
     owner: PublicKey,
     validateStatePubkey: PublicKey,
-    amount: bigint
+    amount: bigint,
 ): TransactionInstruction {
-    const keys = [source, mint, destination, owner, validateStatePubkey].map((pubkey) => ({
+    const keys = [source, mint, destination, owner, validateStatePubkey].map(pubkey => ({
         pubkey,
         isSigner: false,
         isWritable: false,
@@ -195,7 +195,7 @@ export async function addExtraAccountMetasForExecute(
     destination: PublicKey,
     owner: PublicKey,
     amount: number | bigint,
-    commitment?: Commitment
+    commitment?: Commitment,
 ) {
     const validateStatePubkey = getExtraAccountMetaAddress(mint, programId);
     const validateStateAccount = await connection.getAccountInfo(validateStatePubkey, commitment);
@@ -205,7 +205,7 @@ export async function addExtraAccountMetasForExecute(
     const validateStateData = getExtraAccountMetas(validateStateAccount);
 
     // Check to make sure the provided keys are in the instruction
-    if (![source, mint, destination, owner].every((key) => instruction.keys.some((meta) => meta.pubkey.equals(key)))) {
+    if (![source, mint, destination, owner].every(key => instruction.keys.some(meta => meta.pubkey.equals(key)))) {
         throw new Error('Missing required account in instruction');
     }
 
@@ -216,7 +216,7 @@ export async function addExtraAccountMetasForExecute(
         destination,
         owner,
         validateStatePubkey,
-        BigInt(amount)
+        BigInt(amount),
     );
 
     for (const extraAccountMeta of validateStateData) {
@@ -227,10 +227,10 @@ export async function addExtraAccountMetasForExecute(
                     extraAccountMeta,
                     executeInstruction.keys,
                     executeInstruction.data,
-                    executeInstruction.programId
+                    executeInstruction.programId,
                 ),
-                executeInstruction.keys
-            )
+                executeInstruction.keys,
+            ),
         );
     }
 
@@ -268,7 +268,7 @@ export async function createTransferCheckedWithTransferHookInstruction(
     decimals: number,
     multiSigners: (Signer | PublicKey)[] = [],
     commitment?: Commitment,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ) {
     const instruction = createTransferCheckedInstruction(
         source,
@@ -278,7 +278,7 @@ export async function createTransferCheckedWithTransferHookInstruction(
         amount,
         decimals,
         multiSigners,
-        programId
+        programId,
     );
 
     const mintInfo = await getMint(connection, mint, commitment, programId);
@@ -294,7 +294,7 @@ export async function createTransferCheckedWithTransferHookInstruction(
             destination,
             owner,
             amount,
-            commitment
+            commitment,
         );
     }
 
@@ -329,7 +329,7 @@ export async function createTransferCheckedWithFeeAndTransferHookInstruction(
     fee: bigint,
     multiSigners: (Signer | PublicKey)[] = [],
     commitment?: Commitment,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ) {
     const instruction = createTransferCheckedWithFeeInstruction(
         source,
@@ -340,7 +340,7 @@ export async function createTransferCheckedWithFeeAndTransferHookInstruction(
         decimals,
         fee,
         multiSigners,
-        programId
+        programId,
     );
 
     const mintInfo = await getMint(connection, mint, commitment, programId);
@@ -356,7 +356,7 @@ export async function createTransferCheckedWithFeeAndTransferHookInstruction(
             destination,
             owner,
             amount,
-            commitment
+            commitment,
         );
     }
 

--- a/token/js/src/extensions/transferHook/seeds.ts
+++ b/token/js/src/extensions/transferHook/seeds.ts
@@ -60,7 +60,7 @@ function unpackSeedAccountKey(seeds: Uint8Array, previousMetas: AccountMeta[]): 
 async function unpackSeedAccountData(
     seeds: Uint8Array,
     previousMetas: AccountMeta[],
-    connection: Connection
+    connection: Connection,
 ): Promise<Seed> {
     if (seeds.length < 3) {
         throw new TokenTransferHookInvalidSeed();
@@ -87,7 +87,7 @@ async function unpackFirstSeed(
     seeds: Uint8Array,
     previousMetas: AccountMeta[],
     instructionData: Buffer,
-    connection: Connection
+    connection: Connection,
 ): Promise<Seed | null> {
     const [discriminator, ...rest] = seeds;
     const remaining = new Uint8Array(rest);
@@ -111,7 +111,7 @@ export async function unpackSeeds(
     seeds: Uint8Array,
     previousMetas: AccountMeta[],
     instructionData: Buffer,
-    connection: Connection
+    connection: Connection,
 ): Promise<Buffer[]> {
     const unpackedSeeds: Buffer[] = [];
     let i = 0;

--- a/token/js/src/extensions/transferHook/state.ts
+++ b/token/js/src/extensions/transferHook/state.ts
@@ -111,7 +111,7 @@ export async function resolveExtraAccountMeta(
     extraMeta: ExtraAccountMeta,
     previousMetas: AccountMeta[],
     instructionData: Buffer,
-    transferHookProgramId: PublicKey
+    transferHookProgramId: PublicKey,
 ): Promise<AccountMeta> {
     if (extraMeta.discriminator === 0) {
         return {

--- a/token/js/src/instructions/amountToUiAmount.ts
+++ b/token/js/src/instructions/amountToUiAmount.ts
@@ -35,7 +35,7 @@ export const amountToUiAmountInstructionData = struct<AmountToUiAmountInstructio
 export function createAmountToUiAmountInstruction(
     mint: PublicKey,
     amount: number | bigint,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [{ pubkey: mint, isSigner: false, isWritable: false }];
 
@@ -45,7 +45,7 @@ export function createAmountToUiAmountInstruction(
             instruction: TokenInstruction.AmountToUiAmount,
             amount: BigInt(amount),
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -73,7 +73,7 @@ export interface DecodedAmountToUiAmountInstruction {
  */
 export function decodeAmountToUiAmountInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedAmountToUiAmountInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== amountToUiAmountInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/approve.ts
+++ b/token/js/src/instructions/approve.ts
@@ -39,7 +39,7 @@ export function createApproveInstruction(
     owner: PublicKey,
     amount: number | bigint,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -47,7 +47,7 @@ export function createApproveInstruction(
             { pubkey: delegate, isSigner: false, isWritable: false },
         ],
         owner,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(approveInstructionData.span);
@@ -56,7 +56,7 @@ export function createApproveInstruction(
             instruction: TokenInstruction.Approve,
             amount: BigInt(amount),
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -87,7 +87,7 @@ export interface DecodedApproveInstruction {
  */
 export function decodeApproveInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedApproveInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== approveInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/approveChecked.ts
+++ b/token/js/src/instructions/approveChecked.ts
@@ -48,7 +48,7 @@ export function createApproveCheckedInstruction(
     amount: number | bigint,
     decimals: number,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -57,7 +57,7 @@ export function createApproveCheckedInstruction(
             { pubkey: delegate, isSigner: false, isWritable: false },
         ],
         owner,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(approveCheckedInstructionData.span);
@@ -67,7 +67,7 @@ export function createApproveCheckedInstruction(
             amount: BigInt(amount),
             decimals,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -100,7 +100,7 @@ export interface DecodedApproveCheckedInstruction {
  */
 export function decodeApproveCheckedInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedApproveCheckedInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== approveCheckedInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/associatedTokenAccount.ts
+++ b/token/js/src/instructions/associatedTokenAccount.ts
@@ -20,7 +20,7 @@ export function createAssociatedTokenAccountInstruction(
     owner: PublicKey,
     mint: PublicKey,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     return buildAssociatedTokenAccountInstruction(
         payer,
@@ -29,7 +29,7 @@ export function createAssociatedTokenAccountInstruction(
         mint,
         Buffer.alloc(0),
         programId,
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 }
 
@@ -51,7 +51,7 @@ export function createAssociatedTokenAccountIdempotentInstruction(
     owner: PublicKey,
     mint: PublicKey,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     return buildAssociatedTokenAccountInstruction(
         payer,
@@ -60,7 +60,7 @@ export function createAssociatedTokenAccountIdempotentInstruction(
         mint,
         Buffer.from([1]),
         programId,
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 }
 
@@ -71,7 +71,7 @@ function buildAssociatedTokenAccountInstruction(
     mint: PublicKey,
     instructionData: Buffer,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [
         { pubkey: payer, isSigner: true, isWritable: true },
@@ -111,7 +111,7 @@ export function createRecoverNestedInstruction(
     ownerMint: PublicKey,
     owner: PublicKey,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [
         { pubkey: nestedAssociatedToken, isSigner: false, isWritable: true },

--- a/token/js/src/instructions/burn.ts
+++ b/token/js/src/instructions/burn.ts
@@ -39,7 +39,7 @@ export function createBurnInstruction(
     owner: PublicKey,
     amount: number | bigint,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -47,7 +47,7 @@ export function createBurnInstruction(
             { pubkey: mint, isSigner: false, isWritable: true },
         ],
         owner,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(burnInstructionData.span);
@@ -56,7 +56,7 @@ export function createBurnInstruction(
             instruction: TokenInstruction.Burn,
             amount: BigInt(amount),
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -87,7 +87,7 @@ export interface DecodedBurnInstruction {
  */
 export function decodeBurnInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedBurnInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== burnInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/burnChecked.ts
+++ b/token/js/src/instructions/burnChecked.ts
@@ -46,7 +46,7 @@ export function createBurnCheckedInstruction(
     amount: number | bigint,
     decimals: number,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -54,7 +54,7 @@ export function createBurnCheckedInstruction(
             { pubkey: mint, isSigner: false, isWritable: true },
         ],
         owner,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(burnCheckedInstructionData.span);
@@ -64,7 +64,7 @@ export function createBurnCheckedInstruction(
             amount: BigInt(amount),
             decimals,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -96,7 +96,7 @@ export interface DecodedBurnCheckedInstruction {
  */
 export function decodeBurnCheckedInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedBurnCheckedInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== burnCheckedInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/closeAccount.ts
+++ b/token/js/src/instructions/closeAccount.ts
@@ -35,7 +35,7 @@ export function createCloseAccountInstruction(
     destination: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -43,7 +43,7 @@ export function createCloseAccountInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         authority,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(closeAccountInstructionData.span);
@@ -76,7 +76,7 @@ export interface DecodedCloseAccountInstruction {
  */
 export function decodeCloseAccountInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedCloseAccountInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== closeAccountInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/createNativeMint.ts
+++ b/token/js/src/instructions/createNativeMint.ts
@@ -26,7 +26,7 @@ export const createNativeMintInstructionData = struct<CreateNativeMintInstructio
 export function createCreateNativeMintInstruction(
     payer: PublicKey,
     nativeMintId = NATIVE_MINT_2022,
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();

--- a/token/js/src/instructions/decode.ts
+++ b/token/js/src/instructions/decode.ts
@@ -79,7 +79,7 @@ export type DecodedInstruction =
 /** TODO: docs */
 export function decodeInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedInstruction {
     if (!instruction.data.length) throw new TokenInvalidInstructionDataError();
 
@@ -122,14 +122,14 @@ export function isInitializeMintInstruction(decoded: DecodedInstruction): decode
 
 /** TODO: docs */
 export function isInitializeAccountInstruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedInitializeAccountInstruction {
     return decoded.data.instruction === TokenInstruction.InitializeAccount;
 }
 
 /** TODO: docs */
 export function isInitializeMultisigInstruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedInitializeMultisigInstruction {
     return decoded.data.instruction === TokenInstruction.InitializeMultisig;
 }
@@ -181,7 +181,7 @@ export function isThawAccountInstruction(decoded: DecodedInstruction): decoded i
 
 /** TODO: docs */
 export function isTransferCheckedInstruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedTransferCheckedInstruction {
     return decoded.data.instruction === TokenInstruction.TransferChecked;
 }
@@ -203,7 +203,7 @@ export function isBurnCheckedInstruction(decoded: DecodedInstruction): decoded i
 
 /** TODO: docs */
 export function isInitializeAccount2Instruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedInitializeAccount2Instruction {
     return decoded.data.instruction === TokenInstruction.InitializeAccount2;
 }
@@ -215,7 +215,7 @@ export function isSyncNativeInstruction(decoded: DecodedInstruction): decoded is
 
 /** TODO: docs */
 export function isInitializeAccount3Instruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedInitializeAccount3Instruction {
     return decoded.data.instruction === TokenInstruction.InitializeAccount3;
 }
@@ -229,21 +229,21 @@ export function isInitializeAccount3Instruction(
 
 /** TODO: docs */
 export function isInitializeMint2Instruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedInitializeMint2Instruction {
     return decoded.data.instruction === TokenInstruction.InitializeMint2;
 }
 
 /** TODO: docs */
 export function isAmountToUiAmountInstruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedAmountToUiAmountInstruction {
     return decoded.data.instruction === TokenInstruction.AmountToUiAmount;
 }
 
 /** TODO: docs */
 export function isUiamountToAmountInstruction(
-    decoded: DecodedInstruction
+    decoded: DecodedInstruction,
 ): decoded is DecodedUiAmountToAmountInstruction {
     return decoded.data.instruction === TokenInstruction.UiAmountToAmount;
 }

--- a/token/js/src/instructions/freezeAccount.ts
+++ b/token/js/src/instructions/freezeAccount.ts
@@ -35,7 +35,7 @@ export function createFreezeAccountInstruction(
     mint: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -43,7 +43,7 @@ export function createFreezeAccountInstruction(
             { pubkey: mint, isSigner: false, isWritable: false },
         ],
         authority,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(freezeAccountInstructionData.span);
@@ -76,7 +76,7 @@ export interface DecodedFreezeAccountInstruction {
  */
 export function decodeFreezeAccountInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedFreezeAccountInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== freezeAccountInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/initializeAccount.ts
+++ b/token/js/src/instructions/initializeAccount.ts
@@ -32,7 +32,7 @@ export function createInitializeAccountInstruction(
     account: PublicKey,
     mint: PublicKey,
     owner: PublicKey,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [
         { pubkey: account, isSigner: false, isWritable: true },
@@ -71,7 +71,7 @@ export interface DecodedInitializeAccountInstruction {
  */
 export function decodeInitializeAccountInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeAccountInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeAccountInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/initializeAccount2.ts
+++ b/token/js/src/instructions/initializeAccount2.ts
@@ -35,7 +35,7 @@ export function createInitializeAccount2Instruction(
     account: PublicKey,
     mint: PublicKey,
     owner: PublicKey,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [
         { pubkey: account, isSigner: false, isWritable: true },
@@ -71,7 +71,7 @@ export interface DecodedInitializeAccount2Instruction {
  */
 export function decodeInitializeAccount2Instruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeAccount2Instruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeAccount2InstructionData.span)

--- a/token/js/src/instructions/initializeAccount3.ts
+++ b/token/js/src/instructions/initializeAccount3.ts
@@ -35,7 +35,7 @@ export function createInitializeAccount3Instruction(
     account: PublicKey,
     mint: PublicKey,
     owner: PublicKey,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [
         { pubkey: account, isSigner: false, isWritable: true },
@@ -69,7 +69,7 @@ export interface DecodedInitializeAccount3Instruction {
  */
 export function decodeInitializeAccount3Instruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeAccount3Instruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeAccount3InstructionData.span)

--- a/token/js/src/instructions/initializeImmutableOwner.ts
+++ b/token/js/src/instructions/initializeImmutableOwner.ts
@@ -29,7 +29,7 @@ export const initializeImmutableOwnerInstructionData = struct<InitializeImmutabl
  */
 export function createInitializeImmutableOwnerInstruction(
     account: PublicKey,
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     const keys = [{ pubkey: account, isSigner: false, isWritable: true }];
 
@@ -38,7 +38,7 @@ export function createInitializeImmutableOwnerInstruction(
         {
             instruction: TokenInstruction.InitializeImmutableOwner,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -65,7 +65,7 @@ export interface DecodedInitializeImmutableOwnerInstruction {
  */
 export function decodeInitializeImmutableOwnerInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedInitializeImmutableOwnerInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeImmutableOwnerInstructionData.span)

--- a/token/js/src/instructions/initializeMint.ts
+++ b/token/js/src/instructions/initializeMint.ts
@@ -44,7 +44,7 @@ export function createInitializeMintInstruction(
     decimals: number,
     mintAuthority: PublicKey,
     freezeAuthority: PublicKey | null,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [
         { pubkey: mint, isSigner: false, isWritable: true },
@@ -59,7 +59,7 @@ export function createInitializeMintInstruction(
             mintAuthority,
             freezeAuthority,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -90,7 +90,7 @@ export interface DecodedInitializeMintInstruction {
  */
 export function decodeInitializeMintInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeMintInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeMintInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/initializeMint2.ts
+++ b/token/js/src/instructions/initializeMint2.ts
@@ -44,7 +44,7 @@ export function createInitializeMint2Instruction(
     decimals: number,
     mintAuthority: PublicKey,
     freezeAuthority: PublicKey | null,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
 
@@ -56,7 +56,7 @@ export function createInitializeMint2Instruction(
             mintAuthority,
             freezeAuthority,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -86,7 +86,7 @@ export interface DecodedInitializeMint2Instruction {
  */
 export function decodeInitializeMint2Instruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeMint2Instruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeMint2InstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/initializeMintCloseAuthority.ts
+++ b/token/js/src/instructions/initializeMintCloseAuthority.ts
@@ -36,7 +36,7 @@ export const initializeMintCloseAuthorityInstructionData = struct<InitializeMint
 export function createInitializeMintCloseAuthorityInstruction(
     mint: PublicKey,
     closeAuthority: PublicKey | null,
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -49,7 +49,7 @@ export function createInitializeMintCloseAuthorityInstruction(
             instruction: TokenInstruction.InitializeMintCloseAuthority,
             closeAuthority,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -77,7 +77,7 @@ export interface DecodedInitializeMintCloseAuthorityInstruction {
  */
 export function decodeInitializeMintCloseAuthorityInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedInitializeMintCloseAuthorityInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeMintCloseAuthorityInstructionData.span)

--- a/token/js/src/instructions/initializeMultisig.ts
+++ b/token/js/src/instructions/initializeMultisig.ts
@@ -37,7 +37,7 @@ export function createInitializeMultisigInstruction(
     account: PublicKey,
     signers: (Signer | PublicKey)[],
     m: number,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [
         { pubkey: account, isSigner: false, isWritable: true },
@@ -57,7 +57,7 @@ export function createInitializeMultisigInstruction(
             instruction: TokenInstruction.InitializeMultisig,
             m,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -87,7 +87,7 @@ export interface DecodedInitializeMultisigInstruction {
  */
 export function decodeInitializeMultisigInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeMultisigInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializeMultisigInstructionData.span)

--- a/token/js/src/instructions/initializeNonTransferableMint.ts
+++ b/token/js/src/instructions/initializeNonTransferableMint.ts
@@ -25,7 +25,7 @@ export const initializeNonTransferableMintInstructionData = struct<InitializeNon
  */
 export function createInitializeNonTransferableMintInstruction(
     mint: PublicKey,
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -37,7 +37,7 @@ export function createInitializeNonTransferableMintInstruction(
         {
             instruction: TokenInstruction.InitializeNonTransferableMint,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });

--- a/token/js/src/instructions/initializePermanentDelegate.ts
+++ b/token/js/src/instructions/initializePermanentDelegate.ts
@@ -37,7 +37,7 @@ export const initializePermanentDelegateInstructionData = struct<InitializePerma
 export function createInitializePermanentDelegateInstruction(
     mint: PublicKey,
     permanentDelegate: PublicKey | null,
-    programId: PublicKey
+    programId: PublicKey,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();
@@ -50,7 +50,7 @@ export function createInitializePermanentDelegateInstruction(
             instruction: TokenInstruction.InitializePermanentDelegate,
             delegate: permanentDelegate || new PublicKey(0),
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -78,7 +78,7 @@ export interface DecodedInitializePermanentDelegateInstruction {
  */
 export function decodeInitializePermanentDelegateInstruction(
     instruction: TransactionInstruction,
-    programId: PublicKey
+    programId: PublicKey,
 ): DecodedInitializePermanentDelegateInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== initializePermanentDelegateInstructionData.span)

--- a/token/js/src/instructions/internal.ts
+++ b/token/js/src/instructions/internal.ts
@@ -5,7 +5,7 @@ import { PublicKey } from '@solana/web3.js';
 export function addSigners(
     keys: AccountMeta[],
     ownerOrAuthority: PublicKey,
-    multiSigners: (Signer | PublicKey)[]
+    multiSigners: (Signer | PublicKey)[],
 ): AccountMeta[] {
     if (multiSigners.length) {
         keys.push({ pubkey: ownerOrAuthority, isSigner: false, isWritable: false });

--- a/token/js/src/instructions/mintTo.ts
+++ b/token/js/src/instructions/mintTo.ts
@@ -39,7 +39,7 @@ export function createMintToInstruction(
     authority: PublicKey,
     amount: number | bigint,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -47,7 +47,7 @@ export function createMintToInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         authority,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(mintToInstructionData.span);
@@ -56,7 +56,7 @@ export function createMintToInstruction(
             instruction: TokenInstruction.MintTo,
             amount: BigInt(amount),
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -87,7 +87,7 @@ export interface DecodedMintToInstruction {
  */
 export function decodeMintToInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedMintToInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== mintToInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/mintToChecked.ts
+++ b/token/js/src/instructions/mintToChecked.ts
@@ -46,7 +46,7 @@ export function createMintToCheckedInstruction(
     amount: number | bigint,
     decimals: number,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -54,7 +54,7 @@ export function createMintToCheckedInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         authority,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(mintToCheckedInstructionData.span);
@@ -64,7 +64,7 @@ export function createMintToCheckedInstruction(
             amount: BigInt(amount),
             decimals,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -96,7 +96,7 @@ export interface DecodedMintToCheckedInstruction {
  */
 export function decodeMintToCheckedInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedMintToCheckedInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== mintToCheckedInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/reallocate.ts
+++ b/token/js/src/instructions/reallocate.ts
@@ -31,7 +31,7 @@ export function createReallocateInstruction(
     extensionTypes: ExtensionType[],
     owner: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_2022_PROGRAM_ID
+    programId = TOKEN_2022_PROGRAM_ID,
 ): TransactionInstruction {
     if (!programSupportsExtensions(programId)) {
         throw new TokenUnsupportedInstructionError();

--- a/token/js/src/instructions/revoke.ts
+++ b/token/js/src/instructions/revoke.ts
@@ -33,7 +33,7 @@ export function createRevokeInstruction(
     account: PublicKey,
     owner: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners([{ pubkey: account, isSigner: false, isWritable: true }], owner, multiSigners);
 
@@ -66,7 +66,7 @@ export interface DecodedRevokeInstruction {
  */
 export function decodeRevokeInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedRevokeInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== revokeInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/setAuthority.ts
+++ b/token/js/src/instructions/setAuthority.ts
@@ -64,7 +64,7 @@ export function createSetAuthorityInstruction(
     authorityType: AuthorityType,
     newAuthority: PublicKey | null,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners([{ pubkey: account, isSigner: false, isWritable: true }], currentAuthority, multiSigners);
 
@@ -75,7 +75,7 @@ export function createSetAuthorityInstruction(
             authorityType,
             newAuthority,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -106,7 +106,7 @@ export interface DecodedSetAuthorityInstruction {
  */
 export function decodeSetAuthorityInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedSetAuthorityInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== setAuthorityInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/syncNative.ts
+++ b/token/js/src/instructions/syncNative.ts
@@ -56,7 +56,7 @@ export interface DecodedSyncNativeInstruction {
  */
 export function decodeSyncNativeInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedSyncNativeInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== syncNativeInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/thawAccount.ts
+++ b/token/js/src/instructions/thawAccount.ts
@@ -35,7 +35,7 @@ export function createThawAccountInstruction(
     mint: PublicKey,
     authority: PublicKey,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -43,7 +43,7 @@ export function createThawAccountInstruction(
             { pubkey: mint, isSigner: false, isWritable: false },
         ],
         authority,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(thawAccountInstructionData.span);
@@ -76,7 +76,7 @@ export interface DecodedThawAccountInstruction {
  */
 export function decodeThawAccountInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedThawAccountInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== thawAccountInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/transfer.ts
+++ b/token/js/src/instructions/transfer.ts
@@ -39,7 +39,7 @@ export function createTransferInstruction(
     owner: PublicKey,
     amount: number | bigint,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -47,7 +47,7 @@ export function createTransferInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         owner,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(transferInstructionData.span);
@@ -56,7 +56,7 @@ export function createTransferInstruction(
             instruction: TokenInstruction.Transfer,
             amount: BigInt(amount),
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -87,7 +87,7 @@ export interface DecodedTransferInstruction {
  */
 export function decodeTransferInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedTransferInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== transferInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/transferChecked.ts
+++ b/token/js/src/instructions/transferChecked.ts
@@ -48,7 +48,7 @@ export function createTransferCheckedInstruction(
     amount: number | bigint,
     decimals: number,
     multiSigners: (Signer | PublicKey)[] = [],
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = addSigners(
         [
@@ -57,7 +57,7 @@ export function createTransferCheckedInstruction(
             { pubkey: destination, isSigner: false, isWritable: true },
         ],
         owner,
-        multiSigners
+        multiSigners,
     );
 
     const data = Buffer.alloc(transferCheckedInstructionData.span);
@@ -67,7 +67,7 @@ export function createTransferCheckedInstruction(
             amount: BigInt(amount),
             decimals,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -100,7 +100,7 @@ export interface DecodedTransferCheckedInstruction {
  */
 export function decodeTransferCheckedInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedTransferCheckedInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     if (instruction.data.length !== transferCheckedInstructionData.span) throw new TokenInvalidInstructionDataError();

--- a/token/js/src/instructions/uiAmountToAmount.ts
+++ b/token/js/src/instructions/uiAmountToAmount.ts
@@ -30,7 +30,7 @@ export interface UiAmountToAmountInstructionData {
 export function createUiAmountToAmountInstruction(
     mint: PublicKey,
     amount: string,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): TransactionInstruction {
     const keys = [{ pubkey: mint, isSigner: false, isWritable: false }];
     const buf = Buffer.from(amount, 'utf8');
@@ -45,7 +45,7 @@ export function createUiAmountToAmountInstruction(
             instruction: TokenInstruction.UiAmountToAmount,
             amount: buf,
         },
-        data
+        data,
     );
 
     return new TransactionInstruction({ keys, programId, data });
@@ -73,7 +73,7 @@ export interface DecodedUiAmountToAmountInstruction {
  */
 export function decodeUiAmountToAmountInstruction(
     instruction: TransactionInstruction,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): DecodedUiAmountToAmountInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
     const uiAmountToAmountInstructionData = struct<UiAmountToAmountInstructionData>([

--- a/token/js/src/state/account.ts
+++ b/token/js/src/state/account.ts
@@ -97,7 +97,7 @@ export async function getAccount(
     connection: Connection,
     address: PublicKey,
     commitment?: Commitment,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<Account> {
     const info = await connection.getAccountInfo(address, commitment);
     return unpackAccount(address, info, programId);
@@ -117,7 +117,7 @@ export async function getMultipleAccounts(
     connection: Connection,
     addresses: PublicKey[],
     commitment?: Commitment,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<Account[]> {
     const infos = await connection.getMultipleAccountsInfo(addresses, commitment);
     return addresses.map((address, i) => unpackAccount(address, infos[i], programId));
@@ -132,7 +132,7 @@ export async function getMultipleAccounts(
  */
 export async function getMinimumBalanceForRentExemptAccount(
     connection: Connection,
-    commitment?: Commitment
+    commitment?: Commitment,
 ): Promise<number> {
     return await getMinimumBalanceForRentExemptAccountWithExtensions(connection, [], commitment);
 }
@@ -147,7 +147,7 @@ export async function getMinimumBalanceForRentExemptAccount(
 export async function getMinimumBalanceForRentExemptAccountWithExtensions(
     connection: Connection,
     extensions: ExtensionType[],
-    commitment?: Commitment
+    commitment?: Commitment,
 ): Promise<number> {
     const accountLen = getAccountLen(extensions);
     return await connection.getMinimumBalanceForRentExemption(accountLen, commitment);
@@ -165,7 +165,7 @@ export async function getMinimumBalanceForRentExemptAccountWithExtensions(
 export function unpackAccount(
     address: PublicKey,
     info: AccountInfo<Buffer> | null,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Account {
     if (!info) throw new TokenAccountNotFoundError();
     if (!info.owner.equals(programId)) throw new TokenInvalidAccountOwnerError();

--- a/token/js/src/state/mint.ts
+++ b/token/js/src/state/mint.ts
@@ -76,7 +76,7 @@ export async function getMint(
     connection: Connection,
     address: PublicKey,
     commitment?: Commitment,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<Mint> {
     const info = await connection.getAccountInfo(address, commitment);
     return unpackMint(address, info, programId);
@@ -125,7 +125,7 @@ export function unpackMint(address: PublicKey, info: AccountInfo<Buffer> | null,
  */
 export async function getMinimumBalanceForRentExemptMint(
     connection: Connection,
-    commitment?: Commitment
+    commitment?: Commitment,
 ): Promise<number> {
     return await getMinimumBalanceForRentExemptMintWithExtensions(connection, [], commitment);
 }
@@ -141,7 +141,7 @@ export async function getMinimumBalanceForRentExemptMint(
 export async function getMinimumBalanceForRentExemptMintWithExtensions(
     connection: Connection,
     extensions: ExtensionType[],
-    commitment?: Commitment
+    commitment?: Commitment,
 ): Promise<number> {
     const mintLen = getMintLen(extensions);
     return await connection.getMinimumBalanceForRentExemption(mintLen, commitment);
@@ -164,13 +164,13 @@ export async function getAssociatedTokenAddress(
     owner: PublicKey,
     allowOwnerOffCurve = false,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): Promise<PublicKey> {
     if (!allowOwnerOffCurve && !PublicKey.isOnCurve(owner.toBuffer())) throw new TokenOwnerOffCurveError();
 
     const [address] = await PublicKey.findProgramAddress(
         [owner.toBuffer(), programId.toBuffer(), mint.toBuffer()],
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 
     return address;
@@ -192,13 +192,13 @@ export function getAssociatedTokenAddressSync(
     owner: PublicKey,
     allowOwnerOffCurve = false,
     programId = TOKEN_PROGRAM_ID,
-    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+    associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): PublicKey {
     if (!allowOwnerOffCurve && !PublicKey.isOnCurve(owner.toBuffer())) throw new TokenOwnerOffCurveError();
 
     const [address] = PublicKey.findProgramAddressSync(
         [owner.toBuffer(), programId.toBuffer(), mint.toBuffer()],
-        associatedTokenProgramId
+        associatedTokenProgramId,
     );
 
     return address;

--- a/token/js/src/state/multisig.ts
+++ b/token/js/src/state/multisig.ts
@@ -66,7 +66,7 @@ export async function getMultisig(
     connection: Connection,
     address: PublicKey,
     commitment?: Commitment,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Promise<Multisig> {
     const info = await connection.getAccountInfo(address, commitment);
     return unpackMultisig(address, info, programId);
@@ -84,7 +84,7 @@ export async function getMultisig(
 export function unpackMultisig(
     address: PublicKey,
     info: AccountInfo<Buffer> | null,
-    programId = TOKEN_PROGRAM_ID
+    programId = TOKEN_PROGRAM_ID,
 ): Multisig {
     if (!info) throw new TokenAccountNotFoundError();
     if (!info.owner.equals(programId)) throw new TokenInvalidAccountOwnerError();
@@ -104,7 +104,7 @@ export function unpackMultisig(
  */
 export async function getMinimumBalanceForRentExemptMultisig(
     connection: Connection,
-    commitment?: Commitment
+    commitment?: Commitment,
 ): Promise<number> {
     return await connection.getMinimumBalanceForRentExemption(MULTISIG_SIZE, commitment);
 }

--- a/token/js/test/e2e-2022/closeMint.test.ts
+++ b/token/js/test/e2e-2022/closeMint.test.ts
@@ -51,7 +51,7 @@ describe('closeMint', () => {
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializeMintCloseAuthorityInstruction(mint, closeAuthority.publicKey, TEST_PROGRAM_ID),
-            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID)
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
@@ -95,7 +95,7 @@ describe('closeMint', () => {
             null,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         const mintCloseAuthority = getMintCloseAuthority(mintInfo);

--- a/token/js/test/e2e-2022/cpiGuard.test.ts
+++ b/token/js/test/e2e-2022/cpiGuard.test.ts
@@ -47,7 +47,7 @@ describe('cpiGuard', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const transaction = new Transaction().add(
@@ -58,7 +58,7 @@ describe('cpiGuard', () => {
                 lamports,
                 programId: TEST_PROGRAM_ID,
             }),
-            createInitializeAccountInstruction(account, mint, owner.publicKey, TEST_PROGRAM_ID)
+            createInitializeAccountInstruction(account, mint, owner.publicKey, TEST_PROGRAM_ID),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, accountKeypair], undefined);
@@ -71,7 +71,7 @@ describe('cpiGuard', () => {
         expect(cpiGuard).to.be.null;
 
         let transaction = new Transaction().add(
-            createEnableCpiGuardInstruction(account, owner.publicKey, [], TEST_PROGRAM_ID)
+            createEnableCpiGuardInstruction(account, owner.publicKey, [], TEST_PROGRAM_ID),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, owner], undefined);
 
@@ -84,7 +84,7 @@ describe('cpiGuard', () => {
         }
 
         transaction = new Transaction().add(
-            createDisableCpiGuardInstruction(account, owner.publicKey, [], TEST_PROGRAM_ID)
+            createDisableCpiGuardInstruction(account, owner.publicKey, [], TEST_PROGRAM_ID),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, owner], undefined);
 

--- a/token/js/test/e2e-2022/defaultAccountState.test.ts
+++ b/token/js/test/e2e-2022/defaultAccountState.test.ts
@@ -50,8 +50,8 @@ describe('defaultAccountState', () => {
                 TEST_TOKEN_DECIMALS,
                 mintAuthority.publicKey,
                 freezeAuthority.publicKey,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
@@ -71,7 +71,7 @@ describe('defaultAccountState', () => {
             owner.publicKey,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
         expect(accountInfo.isFrozen).to.be.true;
@@ -86,7 +86,7 @@ describe('defaultAccountState', () => {
             freezeAuthority,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const owner = Keypair.generate();
         const account = await createAccount(
@@ -96,7 +96,7 @@ describe('defaultAccountState', () => {
             owner.publicKey,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
         expect(accountInfo.isFrozen).to.be.false;

--- a/token/js/test/e2e-2022/groupMemberPointer.test.ts
+++ b/token/js/test/e2e-2022/groupMemberPointer.test.ts
@@ -51,15 +51,15 @@ describe('GroupMember pointer', () => {
                 mint.publicKey,
                 mintAuthority.publicKey,
                 memberAddress,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             ),
             createInitializeMintInstruction(
                 mint.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintAuthority.publicKey,
                 null,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
@@ -83,8 +83,8 @@ describe('GroupMember pointer', () => {
                 mintAuthority.publicKey,
                 newGroupMemberAddress,
                 undefined,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintAuthority], undefined);
 
@@ -106,8 +106,8 @@ describe('GroupMember pointer', () => {
                 AuthorityType.GroupMemberPointer,
                 newAuthority,
                 [],
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintAuthority], undefined);
 
@@ -128,8 +128,8 @@ describe('GroupMember pointer', () => {
                 AuthorityType.GroupMemberPointer,
                 null,
                 [],
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintAuthority], undefined);
 

--- a/token/js/test/e2e-2022/groupPointer.test.ts
+++ b/token/js/test/e2e-2022/groupPointer.test.ts
@@ -51,15 +51,15 @@ describe('Group pointer', () => {
                 mint.publicKey,
                 mintAuthority.publicKey,
                 groupAddress,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             ),
             createInitializeMintInstruction(
                 mint.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintAuthority.publicKey,
                 null,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
@@ -83,8 +83,8 @@ describe('Group pointer', () => {
                 mintAuthority.publicKey,
                 newGroupAddress,
                 undefined,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintAuthority], undefined);
 
@@ -106,8 +106,8 @@ describe('Group pointer', () => {
                 AuthorityType.GroupPointer,
                 newAuthority,
                 [],
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintAuthority], undefined);
 
@@ -128,8 +128,8 @@ describe('Group pointer', () => {
                 AuthorityType.GroupPointer,
                 null,
                 [],
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintAuthority], undefined);
 

--- a/token/js/test/e2e-2022/immutableOwner.test.ts
+++ b/token/js/test/e2e-2022/immutableOwner.test.ts
@@ -39,7 +39,7 @@ describe('immutableOwner', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         owner = Keypair.generate();
         const accountLen = getAccountLen(EXTENSIONS);
@@ -55,7 +55,7 @@ describe('immutableOwner', () => {
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializeImmutableOwnerInstruction(account, TEST_PROGRAM_ID),
-            createInitializeAccountInstruction(account, mint, owner.publicKey, TEST_PROGRAM_ID)
+            createInitializeAccountInstruction(account, mint, owner.publicKey, TEST_PROGRAM_ID),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, accountKeypair], undefined);
     });
@@ -71,8 +71,8 @@ describe('immutableOwner', () => {
                 owner.publicKey,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         ).to.be.rejected;
     });
 });

--- a/token/js/test/e2e-2022/interestBearingMint.test.ts
+++ b/token/js/test/e2e-2022/interestBearingMint.test.ts
@@ -46,7 +46,7 @@ describe('interestBearingMint', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         const interestBearingMintConfigState = getInterestBearingMintConfigState(mintInfo);
@@ -67,7 +67,7 @@ describe('interestBearingMint', () => {
             TEST_UPDATE_RATE,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfoUpdatedRate = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         const updatedRateConfigState = getInterestBearingMintConfigState(mintInfoUpdatedRate);
@@ -91,7 +91,7 @@ describe('interestBearingMint', () => {
             null,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         const rateConfigState = getInterestBearingMintConfigState(mintInfo);

--- a/token/js/test/e2e-2022/memoTransfer.test.ts
+++ b/token/js/test/e2e-2022/memoTransfer.test.ts
@@ -49,7 +49,7 @@ describe('memoTransfer', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         source = await createAccount(
@@ -59,7 +59,7 @@ describe('memoTransfer', () => {
             owner.publicKey,
             undefined, // uses ATA by default
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const destinationKeypair = Keypair.generate();
@@ -76,7 +76,7 @@ describe('memoTransfer', () => {
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializeAccountInstruction(destination, mint, owner.publicKey, TEST_PROGRAM_ID),
-            createEnableRequiredMemoTransfersInstruction(destination, owner.publicKey, [], TEST_PROGRAM_ID)
+            createEnableRequiredMemoTransfersInstruction(destination, owner.publicKey, [], TEST_PROGRAM_ID),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, owner, destinationKeypair], undefined);
@@ -89,7 +89,7 @@ describe('memoTransfer', () => {
             TRANSFER_AMOUNT * 10,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     it('fails without memo when enabled', async () => {
@@ -112,7 +112,7 @@ describe('memoTransfer', () => {
     it('works with memo when enabled', async () => {
         const transaction = new Transaction().add(
             createMemoInstruction('transfer with a memo', [payer.publicKey, owner.publicKey]),
-            createTransferInstruction(source, destination, owner.publicKey, TRANSFER_AMOUNT, [], TEST_PROGRAM_ID)
+            createTransferInstruction(source, destination, owner.publicKey, TRANSFER_AMOUNT, [], TEST_PROGRAM_ID),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, owner], {
             preflightCommitment: 'confirmed',

--- a/token/js/test/e2e-2022/metadataPointer.test.ts
+++ b/token/js/test/e2e-2022/metadataPointer.test.ts
@@ -49,15 +49,15 @@ describe('Metadata pointer', () => {
                 mint.publicKey,
                 mintAuthority.publicKey,
                 metadataAddress,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             ),
             createInitializeMintInstruction(
                 mint.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintAuthority.publicKey,
                 null,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
@@ -81,8 +81,8 @@ describe('Metadata pointer', () => {
                 mintAuthority.publicKey,
                 newMetadataAddress,
                 undefined,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintAuthority], undefined);
 

--- a/token/js/test/e2e-2022/nonTransferableMint.test.ts
+++ b/token/js/test/e2e-2022/nonTransferableMint.test.ts
@@ -46,7 +46,7 @@ describe('nonTransferable', () => {
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializeNonTransferableMintInstruction(mint, TEST_PROGRAM_ID),
-            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID)
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
@@ -71,7 +71,7 @@ describe('nonTransferable', () => {
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializeImmutableOwnerInstruction(source, TEST_PROGRAM_ID),
-            createInitializeAccountInstruction(source, mint, owner.publicKey, TEST_PROGRAM_ID)
+            createInitializeAccountInstruction(source, mint, owner.publicKey, TEST_PROGRAM_ID),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, sourceKeypair], undefined);
 
@@ -86,7 +86,7 @@ describe('nonTransferable', () => {
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializeImmutableOwnerInstruction(destination, TEST_PROGRAM_ID),
-            createInitializeAccountInstruction(destination, mint, owner.publicKey, TEST_PROGRAM_ID)
+            createInitializeAccountInstruction(destination, mint, owner.publicKey, TEST_PROGRAM_ID),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, destinationKeypair], undefined);
 

--- a/token/js/test/e2e-2022/permanentDelegate.test.ts
+++ b/token/js/test/e2e-2022/permanentDelegate.test.ts
@@ -48,7 +48,7 @@ describe('permanentDelegate', () => {
                 programId: TEST_PROGRAM_ID,
             }),
             createInitializePermanentDelegateInstruction(mint, permanentDelegate.publicKey, TEST_PROGRAM_ID),
-            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID)
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
@@ -74,7 +74,7 @@ describe('permanentDelegate', () => {
             owner2.publicKey,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         account = await createAccount(connection, payer, mint, owner1.publicKey, undefined, undefined, TEST_PROGRAM_ID);
         await mintTo(connection, payer, mint, account, mintAuthority, 5, [], undefined, TEST_PROGRAM_ID);
@@ -89,7 +89,7 @@ describe('permanentDelegate', () => {
             0,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const source_info = await connection.getTokenAccountBalance(account);
         const destination_info = await connection.getTokenAccountBalance(destination);
@@ -112,7 +112,7 @@ describe('permanentDelegate', () => {
             null,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         const permanentDelegateConfig = getPermanentDelegate(mintInfo);

--- a/token/js/test/e2e-2022/reallocate.test.ts
+++ b/token/js/test/e2e-2022/reallocate.test.ts
@@ -28,7 +28,7 @@ describe('reallocate', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         owner = Keypair.generate();
         account = await createAccount(connection, payer, mint, owner.publicKey, undefined, undefined, TEST_PROGRAM_ID);
@@ -41,8 +41,8 @@ describe('reallocate', () => {
                 EXTENSIONS,
                 owner.publicKey,
                 undefined,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, owner], undefined);
         const info = await connection.getAccountInfo(account);

--- a/token/js/test/e2e-2022/tlv.test.ts
+++ b/token/js/test/e2e-2022/tlv.test.ts
@@ -47,7 +47,7 @@ describe('tlv test', () => {
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
 
             const transaction = new Transaction().add(
@@ -58,7 +58,7 @@ describe('tlv test', () => {
                     lamports,
                     programId: TEST_PROGRAM_ID,
                 }),
-                createInitializeAccountInstruction(account, mint, owner.publicKey, TEST_PROGRAM_ID)
+                createInitializeAccountInstruction(account, mint, owner.publicKey, TEST_PROGRAM_ID),
             );
 
             await sendAndConfirmTransaction(connection, transaction, [payer, accountKeypair], undefined);
@@ -80,11 +80,11 @@ describe('tlv test', () => {
                             expect(
                                 getExtensionData(extension, accountInfo.tlvData),
                                 `account parse test failed: found ${ExtensionType[extension]}, but should not have. \
-                                test case: no extensions, ${i} extra bytes`
+                                test case: no extensions, ${i} extra bytes`,
                             ).to.be.null;
                         }
                         return Promise.resolve(undefined);
-                    })
+                    }),
             );
         }
 

--- a/token/js/test/e2e-2022/tokenGroup.test.ts
+++ b/token/js/test/e2e-2022/tokenGroup.test.ts
@@ -53,15 +53,15 @@ describe('tokenGroup', async () => {
                 mint.publicKey,
                 mintAuthority.publicKey,
                 mint.publicKey,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             ),
             createInitializeMintInstruction(
                 mint.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintAuthority.publicKey,
                 null,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
@@ -87,7 +87,7 @@ describe('tokenGroup', async () => {
                 fromPubkey: payer.publicKey,
                 toPubkey: mint.publicKey,
                 lamports,
-            })
+            }),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
 
@@ -100,7 +100,7 @@ describe('tokenGroup', async () => {
             tokenGroup.maxSize,
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const mintInfo = await getMint(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
@@ -125,7 +125,7 @@ describe('tokenGroup', async () => {
             tokenGroup.maxSize,
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const mintInfo = await getMint(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
@@ -148,7 +148,7 @@ describe('tokenGroup', async () => {
                 fromPubkey: payer.publicKey,
                 toPubkey: mint.publicKey,
                 lamports,
-            })
+            }),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
 
@@ -161,7 +161,7 @@ describe('tokenGroup', async () => {
             tokenGroup.maxSize,
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         await tokenGroupUpdateGroupMaxSize(
@@ -172,7 +172,7 @@ describe('tokenGroup', async () => {
             20,
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const mintInfo = await getMint(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
@@ -200,7 +200,7 @@ describe('tokenGroup', async () => {
                 fromPubkey: payer.publicKey,
                 toPubkey: mint.publicKey,
                 lamports,
-            })
+            }),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
 
@@ -213,7 +213,7 @@ describe('tokenGroup', async () => {
             tokenGroup.maxSize,
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const newUpdateAuthority = Keypair.generate();
@@ -225,7 +225,7 @@ describe('tokenGroup', async () => {
             newUpdateAuthority.publicKey,
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const mintInfo = await getMint(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);

--- a/token/js/test/e2e-2022/tokenGroupMember.test.ts
+++ b/token/js/test/e2e-2022/tokenGroupMember.test.ts
@@ -64,18 +64,18 @@ describe('tokenGroupMember', async () => {
                     groupMint.publicKey,
                     groupUpdateAuthority.publicKey,
                     groupMint.publicKey,
-                    TEST_PROGRAM_ID
+                    TEST_PROGRAM_ID,
                 ),
                 createInitializeMintInstruction(
                     groupMint.publicKey,
                     TEST_TOKEN_DECIMALS,
                     groupMintAuthority.publicKey,
                     null,
-                    TEST_PROGRAM_ID
-                )
+                    TEST_PROGRAM_ID,
+                ),
             ),
             [payer, groupMint],
-            undefined
+            undefined,
         );
         await tokenGroupInitializeGroupWithRentTransfer(
             connection,
@@ -86,7 +86,7 @@ describe('tokenGroupMember', async () => {
             3,
             [payer, groupMintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         // Create the member mint.
@@ -104,18 +104,18 @@ describe('tokenGroupMember', async () => {
                     memberMint.publicKey,
                     memberUpdateAuthority.publicKey,
                     memberMint.publicKey,
-                    TEST_PROGRAM_ID
+                    TEST_PROGRAM_ID,
                 ),
                 createInitializeMintInstruction(
                     memberMint.publicKey,
                     TEST_TOKEN_DECIMALS,
                     memberMintAuthority.publicKey,
                     null,
-                    TEST_PROGRAM_ID
-                )
+                    TEST_PROGRAM_ID,
+                ),
             ),
             [payer, memberMint],
-            undefined
+            undefined,
         );
     });
 
@@ -135,7 +135,7 @@ describe('tokenGroupMember', async () => {
             groupUpdateAuthority.publicKey,
             [memberMintAuthority, groupUpdateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const mintInfo = await getMint(connection, memberMint.publicKey, undefined, TEST_PROGRAM_ID);

--- a/token/js/test/e2e-2022/tokenMetadata.test.ts
+++ b/token/js/test/e2e-2022/tokenMetadata.test.ts
@@ -62,15 +62,15 @@ describe('tokenMetadata', async () => {
                 mint.publicKey,
                 updateAuthority.publicKey,
                 mint.publicKey,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             ),
             createInitializeMintInstruction(
                 mint.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintAuthority.publicKey,
                 null,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mint], undefined);
@@ -97,7 +97,7 @@ describe('tokenMetadata', async () => {
                 fromPubkey: payer.publicKey,
                 toPubkey: mint.publicKey,
                 lamports,
-            })
+            }),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
 
@@ -112,7 +112,7 @@ describe('tokenMetadata', async () => {
             tokenMetadata.uri,
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
@@ -138,7 +138,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -163,7 +163,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateField(
             connection,
@@ -174,7 +174,7 @@ describe('tokenMetadata', async () => {
             'TEST',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -199,7 +199,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateFieldWithRentTransfer(
             connection,
@@ -210,7 +210,7 @@ describe('tokenMetadata', async () => {
             'My Shiny New Token Metadata',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -235,7 +235,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateFieldWithRentTransfer(
             connection,
@@ -246,7 +246,7 @@ describe('tokenMetadata', async () => {
             'CUSTOM',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -271,7 +271,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateFieldWithRentTransfer(
             connection,
@@ -282,7 +282,7 @@ describe('tokenMetadata', async () => {
             'CUSTOM',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateField(
             connection,
@@ -293,7 +293,7 @@ describe('tokenMetadata', async () => {
             'test',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -318,7 +318,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateFieldWithRentTransfer(
             connection,
@@ -329,7 +329,7 @@ describe('tokenMetadata', async () => {
             'CUSTOM',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateFieldWithRentTransfer(
             connection,
@@ -340,7 +340,7 @@ describe('tokenMetadata', async () => {
             'My Shiny Custom Field',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -365,7 +365,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataUpdateFieldWithRentTransfer(
             connection,
@@ -376,7 +376,7 @@ describe('tokenMetadata', async () => {
             'CUSTOM',
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataRemoveKey(
             connection,
@@ -387,7 +387,7 @@ describe('tokenMetadata', async () => {
             true,
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -412,7 +412,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         await tokenMetadataRemoveKey(
             connection,
@@ -423,7 +423,7 @@ describe('tokenMetadata', async () => {
             true,
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -448,7 +448,7 @@ describe('tokenMetadata', async () => {
             'uri',
             [mintAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const newAuthority = Keypair.generate().publicKey;
         await tokenMetadataUpdateAuthority(
@@ -459,7 +459,7 @@ describe('tokenMetadata', async () => {
             newAuthority,
             [updateAuthority],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const meta = await getTokenMetadata(connection, mint.publicKey, undefined, TEST_PROGRAM_ID);
         expect(meta).to.deep.equal({
@@ -493,11 +493,11 @@ describe('tokenMetadata', async () => {
             tokenMetadata.uri,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const payerKey = payer.publicKey;
-        const recentBlockhash = await connection.getLatestBlockhash().then((res) => res.blockhash);
+        const recentBlockhash = await connection.getLatestBlockhash().then(res => res.blockhash);
         const instructions = [
             createEmitInstruction({
                 programId: TEST_PROGRAM_ID,
@@ -516,7 +516,7 @@ describe('tokenMetadata', async () => {
 
         const returnDataBase64 = (await connection
             .simulateTransaction(tx)
-            .then((res) => res.value.returnData?.data[0])) as string;
+            .then(res => res.value.returnData?.data[0])) as string;
         const returnData = getBase64Encoder().encode(returnDataBase64);
 
         expect(returnData).to.deep.equal(tokenMetadata.updateAuthority.toBuffer());

--- a/token/js/test/e2e-2022/transferFee.test.ts
+++ b/token/js/test/e2e-2022/transferFee.test.ts
@@ -50,7 +50,7 @@ describe('transferFee', () => {
 
     async function setupTransferFeeMint(
         transferFeeConfigAuthority: PublicKey | null,
-        withdrawWithheldAuthority: PublicKey | null
+        withdrawWithheldAuthority: PublicKey | null,
     ) {
         const mintKeypair = Keypair.generate();
         mint = mintKeypair.publicKey;
@@ -71,9 +71,9 @@ describe('transferFee', () => {
                 withdrawWithheldAuthority,
                 FEE_BASIS_POINTS,
                 MAX_FEE,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             ),
-            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID)
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID),
         );
         await sendAndConfirmTransaction(connection, mintTransaction, [payer, mintKeypair], undefined);
     }
@@ -95,7 +95,7 @@ describe('transferFee', () => {
                 owner.publicKey,
                 undefined,
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             await mintTo(
                 connection,
@@ -106,7 +106,7 @@ describe('transferFee', () => {
                 MINT_AMOUNT,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
 
             const accountKeypair = Keypair.generate();
@@ -117,7 +117,7 @@ describe('transferFee', () => {
                 owner.publicKey,
                 accountKeypair,
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
 
             await transferChecked(
@@ -131,7 +131,7 @@ describe('transferFee', () => {
                 TEST_TOKEN_DECIMALS,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
         });
         it('initializes', async () => {
@@ -168,7 +168,7 @@ describe('transferFee', () => {
                 FEE,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const accountInfo = await getAccount(connection, destinationAccount, undefined, TEST_PROGRAM_ID);
             const transferFeeAmount = getTransferFeeAmount(accountInfo);
@@ -187,7 +187,7 @@ describe('transferFee', () => {
                 [],
                 [destinationAccount],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const accountInfo = await getAccount(connection, destinationAccount, undefined, TEST_PROGRAM_ID);
             expect(accountInfo.amount).to.eql(TRANSFER_AMOUNT);
@@ -204,7 +204,7 @@ describe('transferFee', () => {
                 mint,
                 [destinationAccount],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const accountInfo = await getAccount(connection, destinationAccount, undefined, TEST_PROGRAM_ID);
             const transferFeeAmount = getTransferFeeAmount(accountInfo);
@@ -226,7 +226,7 @@ describe('transferFee', () => {
                 mint,
                 [destinationAccount],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             await withdrawWithheldTokensFromMint(
                 connection,
@@ -236,7 +236,7 @@ describe('transferFee', () => {
                 withdrawWithheldAuthority,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const accountInfo = await getAccount(connection, destinationAccount, undefined, TEST_PROGRAM_ID);
             expect(accountInfo.amount).to.eql(TRANSFER_AMOUNT);
@@ -262,7 +262,7 @@ describe('transferFee', () => {
                 null,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
             const transferFeeConfig = getTransferFeeConfig(mintInfo);
@@ -281,7 +281,7 @@ describe('transferFee', () => {
                 null,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
             const transferFeeConfig = getTransferFeeConfig(mintInfo);
@@ -303,7 +303,7 @@ describe('transferFee', () => {
                 UPDATED_FEE_BASIS_POINTS,
                 UPDATED_MAX_FEE,
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
             const transferFeeConfig = getTransferFeeConfig(mintInfo);

--- a/token/js/test/e2e-2022/transferHook.test.ts
+++ b/token/js/test/e2e-2022/transferHook.test.ts
@@ -51,14 +51,14 @@ describe('transferHook', () => {
             payer.publicKey,
             false,
             TEST_PROGRAM_ID,
-            ASSOCIATED_TOKEN_PROGRAM_ID
+            ASSOCIATED_TOKEN_PROGRAM_ID,
         );
         destinationAta = getAssociatedTokenAddressSync(
             mint,
             destinationAuthority,
             false,
             TEST_PROGRAM_ID,
-            ASSOCIATED_TOKEN_PROGRAM_ID
+            ASSOCIATED_TOKEN_PROGRAM_ID,
         );
         const mintLen = getMintLen(EXTENSIONS);
         const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
@@ -74,9 +74,9 @@ describe('transferHook', () => {
                 mint,
                 transferHookAuthority.publicKey,
                 TRANSFER_HOOK_TEST_PROGRAM_ID,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             ),
-            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, payer.publicKey, null, TEST_PROGRAM_ID)
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, payer.publicKey, null, TEST_PROGRAM_ID),
         );
 
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair], undefined);
@@ -100,7 +100,7 @@ describe('transferHook', () => {
             transferHookAuthority,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         const transferHook = getTransferHook(mintInfo);
@@ -120,7 +120,7 @@ describe('transferHook', () => {
             null,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         const transferHook = getTransferHook(mintInfo);
@@ -157,7 +157,7 @@ describe('transferHook', () => {
                 ],
             },
             data,
-            8
+            8,
         );
 
         const initExtraAccountMetaInstruction = new TransactionInstruction({
@@ -179,7 +179,7 @@ describe('transferHook', () => {
                 payer.publicKey,
                 mint,
                 TEST_PROGRAM_ID,
-                ASSOCIATED_TOKEN_PROGRAM_ID
+                ASSOCIATED_TOKEN_PROGRAM_ID,
             ),
             createMintToCheckedInstruction(
                 mint,
@@ -188,8 +188,8 @@ describe('transferHook', () => {
                 5 * 10 ** TEST_TOKEN_DECIMALS,
                 TEST_TOKEN_DECIMALS,
                 [],
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
 
         await sendAndConfirmTransaction(connection, setupTransaction, [payer]);
@@ -201,7 +201,7 @@ describe('transferHook', () => {
             destinationAuthority,
             undefined,
             TEST_PROGRAM_ID,
-            ASSOCIATED_TOKEN_PROGRAM_ID
+            ASSOCIATED_TOKEN_PROGRAM_ID,
         );
 
         await transferCheckedWithTransferHook(
@@ -215,7 +215,7 @@ describe('transferHook', () => {
             TEST_TOKEN_DECIMALS,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
 });

--- a/token/js/test/e2e/amount.test.ts
+++ b/token/js/test/e2e/amount.test.ts
@@ -23,7 +23,7 @@ describe('Amount', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     it('amountToUiAmount', async () => {

--- a/token/js/test/e2e/burn.test.ts
+++ b/token/js/test/e2e/burn.test.ts
@@ -26,7 +26,7 @@ describe('burn', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     beforeEach(async () => {
@@ -53,7 +53,7 @@ describe('burn', () => {
             TEST_TOKEN_DECIMALS,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
         expect(accountInfo.amount).to.eql(amount - burnAmount);

--- a/token/js/test/e2e/close.test.ts
+++ b/token/js/test/e2e/close.test.ts
@@ -30,7 +30,7 @@ describe('close', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     beforeEach(async () => {

--- a/token/js/test/e2e/create.test.ts
+++ b/token/js/test/e2e/create.test.ts
@@ -32,7 +32,7 @@ describe('createMint', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
@@ -62,7 +62,7 @@ describe('createAccount', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     }),
         it('auxiliary token account', async () => {
@@ -74,7 +74,7 @@ describe('createAccount', () => {
                 owner.publicKey,
                 Keypair.generate(),
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
             expect(accountInfo.mint).to.eql(mint);
@@ -96,7 +96,7 @@ describe('createAccount', () => {
                 owner.publicKey,
                 Keypair.generate(),
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             expect(account2).to.not.eql(account);
         }),
@@ -107,7 +107,7 @@ describe('createAccount', () => {
                 owner.publicKey,
                 false,
                 TEST_PROGRAM_ID,
-                ASSOCIATED_TOKEN_PROGRAM_ID
+                ASSOCIATED_TOKEN_PROGRAM_ID,
             );
 
             // associated account shouldn't exist
@@ -123,7 +123,7 @@ describe('createAccount', () => {
                 undefined,
                 undefined,
                 TEST_PROGRAM_ID,
-                ASSOCIATED_TOKEN_PROGRAM_ID
+                ASSOCIATED_TOKEN_PROGRAM_ID,
             );
             expect(createdAccountInfo.mint).to.eql(mint);
             expect(createdAccountInfo.owner).to.eql(owner.publicKey);
@@ -146,7 +146,7 @@ describe('createAccount', () => {
                 undefined,
                 undefined,
                 TEST_PROGRAM_ID,
-                ASSOCIATED_TOKEN_PROGRAM_ID
+                ASSOCIATED_TOKEN_PROGRAM_ID,
             );
 
             expect(createdAccountInfo).to.eql(accountInfo);
@@ -158,7 +158,7 @@ describe('createAccount', () => {
                 owner.publicKey,
                 false,
                 TEST_PROGRAM_ID,
-                ASSOCIATED_TOKEN_PROGRAM_ID
+                ASSOCIATED_TOKEN_PROGRAM_ID,
             );
 
             // associated account shouldn't exist
@@ -172,7 +172,7 @@ describe('createAccount', () => {
                 owner.publicKey,
                 undefined, // uses ATA by default
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
             expect(createdAddress).to.eql(associatedAddress);
 
@@ -191,8 +191,8 @@ describe('createAccount', () => {
                     owner.publicKey,
                     undefined, // uses ATA by default
                     undefined,
-                    TEST_PROGRAM_ID
-                )
+                    TEST_PROGRAM_ID,
+                ),
             ).to.be.rejected;
 
             // when creating again but with idempotent mode, TX should not throw error
@@ -203,8 +203,8 @@ describe('createAccount', () => {
                     mint,
                     owner.publicKey,
                     undefined,
-                    TEST_PROGRAM_ID
-                )
+                    TEST_PROGRAM_ID,
+                ),
             ).to.be.fulfilled;
         });
 });

--- a/token/js/test/e2e/freeze.test.ts
+++ b/token/js/test/e2e/freeze.test.ts
@@ -32,7 +32,7 @@ describe('freezeThaw', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     beforeEach(async () => {

--- a/token/js/test/e2e/initialize.test.ts
+++ b/token/js/test/e2e/initialize.test.ts
@@ -39,8 +39,8 @@ describe('initialize mint', () => {
                 TEST_TOKEN_DECIMALS,
                 mintAuthority,
                 freezeAuthority,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
         const mintInfo = await getMint(connection, mintKeypair.publicKey, undefined, TEST_PROGRAM_ID);
@@ -65,8 +65,8 @@ describe('initialize mint', () => {
                 TEST_TOKEN_DECIMALS,
                 mintAuthority,
                 null,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
         const mintInfo = await getMint(connection, mintKeypair.publicKey, undefined, TEST_PROGRAM_ID);
@@ -104,8 +104,8 @@ describe('initialize mint 2', () => {
                 TEST_TOKEN_DECIMALS,
                 mintAuthority,
                 freezeAuthority,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
         const mintInfo = await getMint(connection, mintKeypair.publicKey, undefined, TEST_PROGRAM_ID);
@@ -130,8 +130,8 @@ describe('initialize mint 2', () => {
                 TEST_TOKEN_DECIMALS,
                 mintAuthority,
                 null,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
         const mintInfo = await getMint(connection, mintKeypair.publicKey, undefined, TEST_PROGRAM_ID);

--- a/token/js/test/e2e/mint.test.ts
+++ b/token/js/test/e2e/mint.test.ts
@@ -29,7 +29,7 @@ describe('mint', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         owner = Keypair.generate();
         account = await createAccount(connection, payer, mint, owner.publicKey, undefined, undefined, TEST_PROGRAM_ID);
@@ -56,11 +56,11 @@ describe('mint', () => {
             TEST_TOKEN_DECIMALS,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         expect(
-            mintToChecked(connection, payer, mint, account, mintAuthority, amount, 1, [], undefined, TEST_PROGRAM_ID)
+            mintToChecked(connection, payer, mint, account, mintAuthority, amount, 1, [], undefined, TEST_PROGRAM_ID),
         ).to.be.rejected;
     });
 });

--- a/token/js/test/e2e/multisig.test.ts
+++ b/token/js/test/e2e/multisig.test.ts
@@ -51,7 +51,7 @@ describe('multisig', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     beforeEach(async () => {
@@ -63,7 +63,7 @@ describe('multisig', () => {
             multisig,
             Keypair.generate(),
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         account2 = await createAccount(
             connection,
@@ -72,7 +72,7 @@ describe('multisig', () => {
             multisig,
             Keypair.generate(),
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         amount = BigInt(1000);
         await mintTo(connection, payer, mint, account1, mintAuthority, amount, [], undefined, TEST_PROGRAM_ID);
@@ -110,7 +110,7 @@ describe('multisig', () => {
             newOwner,
             signers,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const accountInfo = await getAccount(connection, account1, undefined, TEST_PROGRAM_ID);
         expect(accountInfo.owner).to.eql(newOwner);

--- a/token/js/test/e2e/native.test.ts
+++ b/token/js/test/e2e/native.test.ts
@@ -41,7 +41,7 @@ describe('native', () => {
             undefined,
             undefined,
             TEST_PROGRAM_ID,
-            nativeMint
+            nativeMint,
         );
     });
     it('works', async () => {
@@ -66,9 +66,9 @@ describe('native', () => {
                     fromPubkey: payer.publicKey,
                     toPubkey: account,
                     lamports: additionalLamports,
-                })
+                }),
             ),
-            [payer]
+            [payer],
         );
 
         // no change in the amount

--- a/token/js/test/e2e/recoverNested.test.ts
+++ b/token/js/test/e2e/recoverNested.test.ts
@@ -40,7 +40,7 @@ describe('recoverNested', () => {
             0,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         associatedToken = await createAssociatedTokenAccount(
@@ -49,7 +49,7 @@ describe('recoverNested', () => {
             mint,
             owner.publicKey,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         // nested mint
@@ -63,7 +63,7 @@ describe('recoverNested', () => {
             0,
             nestedMintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         nestedAssociatedToken = getAssociatedTokenAddressSync(
@@ -71,7 +71,7 @@ describe('recoverNested', () => {
             associatedToken,
             true,
             TEST_PROGRAM_ID,
-            ASSOCIATED_TOKEN_PROGRAM_ID
+            ASSOCIATED_TOKEN_PROGRAM_ID,
         );
         const transaction = new Transaction().add(
             createAssociatedTokenAccountInstruction(
@@ -80,8 +80,8 @@ describe('recoverNested', () => {
                 associatedToken,
                 nestedMint,
                 TEST_PROGRAM_ID,
-                ASSOCIATED_TOKEN_PROGRAM_ID
-            )
+                ASSOCIATED_TOKEN_PROGRAM_ID,
+            ),
         );
         await sendAndConfirmTransaction(connection, transaction, [payer], undefined);
 
@@ -95,7 +95,7 @@ describe('recoverNested', () => {
             nestedMintAmount,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     }),
         it('success', async () => {
@@ -106,7 +106,7 @@ describe('recoverNested', () => {
                 nestedMint,
                 owner.publicKey,
                 undefined,
-                TEST_PROGRAM_ID
+                TEST_PROGRAM_ID,
             );
 
             await recoverNested(connection, payer, owner, mint, nestedMint, undefined, TEST_PROGRAM_ID);

--- a/token/js/test/e2e/setAuthority.test.ts
+++ b/token/js/test/e2e/setAuthority.test.ts
@@ -31,7 +31,7 @@ describe('setAuthority', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     beforeEach(async () => {
@@ -43,7 +43,7 @@ describe('setAuthority', () => {
             owner.publicKey,
             Keypair.generate(),
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     it('AccountOwner', async () => {
@@ -57,7 +57,7 @@ describe('setAuthority', () => {
             newOwner.publicKey,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
         expect(accountInfo.owner).to.eql(newOwner.publicKey);
@@ -70,7 +70,7 @@ describe('setAuthority', () => {
             owner.publicKey,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         expect(
             setAuthority(
@@ -82,8 +82,8 @@ describe('setAuthority', () => {
                 owner.publicKey,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         ).to.be.rejected;
     });
     it('MintAuthority', async () => {
@@ -96,7 +96,7 @@ describe('setAuthority', () => {
             null,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         expect(mintInfo.mintAuthority).to.be.null;
@@ -112,7 +112,7 @@ describe('setAuthority', () => {
             closeAuthority.publicKey,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const accountInfo = await getAccount(connection, account, undefined, TEST_PROGRAM_ID);
         expect(accountInfo.closeAuthority).to.eql(closeAuthority.publicKey);
@@ -127,7 +127,7 @@ describe('setAuthority', () => {
             null,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
         expect(mintInfo.freezeAuthority).to.be.null;

--- a/token/js/test/e2e/transfer.test.ts
+++ b/token/js/test/e2e/transfer.test.ts
@@ -42,7 +42,7 @@ describe('transfer', () => {
             TEST_TOKEN_DECIMALS,
             mintKeypair,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
     });
     beforeEach(async () => {
@@ -54,7 +54,7 @@ describe('transfer', () => {
             owner1.publicKey,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         owner2 = Keypair.generate();
         account2 = await createAccount(
@@ -64,7 +64,7 @@ describe('transfer', () => {
             owner2.publicKey,
             undefined,
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         amount = BigInt(1000);
         await mintTo(connection, payer, mint, account1, mintAuthority, amount, [], undefined, TEST_PROGRAM_ID);
@@ -91,7 +91,7 @@ describe('transfer', () => {
             TEST_TOKEN_DECIMALS,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
 
         const destAccountInfo = await getAccount(connection, account2, undefined, TEST_PROGRAM_ID);
@@ -111,8 +111,8 @@ describe('transfer', () => {
                 TEST_TOKEN_DECIMALS - 1,
                 [],
                 undefined,
-                TEST_PROGRAM_ID
-            )
+                TEST_PROGRAM_ID,
+            ),
         ).to.be.rejected;
     });
     it('approveRevoke', async () => {
@@ -127,7 +127,7 @@ describe('transfer', () => {
             delegatedAmount,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const approvedAccountInfo = await getAccount(connection, account1, undefined, TEST_PROGRAM_ID);
         expect(approvedAccountInfo.delegatedAmount).to.eql(delegatedAmount);
@@ -151,7 +151,7 @@ describe('transfer', () => {
             TEST_TOKEN_DECIMALS,
             [],
             undefined,
-            TEST_PROGRAM_ID
+            TEST_PROGRAM_ID,
         );
         const transferAmount = delegatedAmount - BigInt(1);
         await transfer(connection, payer, account1, account2, delegate, transferAmount, [], undefined, TEST_PROGRAM_ID);

--- a/token/js/test/unit/decode.test.ts
+++ b/token/js/test/unit/decode.test.ts
@@ -11,7 +11,7 @@ describe('spl-token-2022 instructions', () => {
         const ix = createInitializeMintCloseAuthorityInstruction(
             Keypair.generate().publicKey,
             Keypair.generate().publicKey,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
         expect(ix.keys).to.have.length(1);
@@ -20,7 +20,7 @@ describe('spl-token-2022 instructions', () => {
         const ix = createInitializePermanentDelegateInstruction(
             Keypair.generate().publicKey,
             Keypair.generate().publicKey,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
         expect(ix.keys).to.have.length(1);

--- a/token/js/test/unit/groupMemberPointer.test.ts
+++ b/token/js/test/unit/groupMemberPointer.test.ts
@@ -21,7 +21,7 @@ describe('SPL Token 2022 GroupMemberPointer Extension', () => {
             mint,
             authority,
             memberAddress,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(instruction).to.deep.equal(
             new TransactionInstruction({
@@ -35,7 +35,7 @@ describe('SPL Token 2022 GroupMemberPointer Extension', () => {
                     AUTHORITY_ADDRESS_BYTES,
                     GROUP_MEMBER_ADDRESS_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can create UpdateGroupMemberPointerInstruction', () => {
@@ -57,7 +57,7 @@ describe('SPL Token 2022 GroupMemberPointer Extension', () => {
                     ]),
                     GROUP_MEMBER_ADDRESS_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can create UpdateGroupMemberPointerInstruction to none', () => {
@@ -79,7 +79,7 @@ describe('SPL Token 2022 GroupMemberPointer Extension', () => {
                     ]),
                     NULL_OPTIONAL_NONZERO_PUBKEY_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can get state with authority and group address', async () => {

--- a/token/js/test/unit/groupPointer.test.ts
+++ b/token/js/test/unit/groupPointer.test.ts
@@ -21,7 +21,7 @@ describe('SPL Token 2022 GroupPointer Extension', () => {
             mint,
             authority,
             groupAddress,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(instruction).to.deep.equal(
             new TransactionInstruction({
@@ -35,7 +35,7 @@ describe('SPL Token 2022 GroupPointer Extension', () => {
                     AUTHORITY_ADDRESS_BYTES,
                     GROUP_ADDRESS_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can create UpdateGroupPointerInstruction', () => {
@@ -57,7 +57,7 @@ describe('SPL Token 2022 GroupPointer Extension', () => {
                     ]),
                     GROUP_ADDRESS_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can create UpdateGroupPointerInstruction to none', () => {
@@ -79,7 +79,7 @@ describe('SPL Token 2022 GroupPointer Extension', () => {
                     ]),
                     NULL_OPTIONAL_NONZERO_PUBKEY_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can get state with authority and group address', async () => {

--- a/token/js/test/unit/index.test.ts
+++ b/token/js/test/unit/index.test.ts
@@ -35,7 +35,7 @@ describe('spl-token instructions', () => {
             Keypair.generate().publicKey,
             Keypair.generate().publicKey,
             1,
-            9
+            9,
         );
         expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
         expect(ix.keys).to.have.length(4);
@@ -52,7 +52,7 @@ describe('spl-token instructions', () => {
             Keypair.generate().publicKey,
             9,
             Keypair.generate().publicKey,
-            null
+            null,
         );
         expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
         expect(ix.keys).to.have.length(1);
@@ -68,7 +68,7 @@ describe('spl-token instructions', () => {
         const ix = createInitializeAccount2Instruction(
             Keypair.generate().publicKey,
             Keypair.generate().publicKey,
-            Keypair.generate().publicKey
+            Keypair.generate().publicKey,
         );
         expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
         expect(ix.keys).to.have.length(3);
@@ -78,7 +78,7 @@ describe('spl-token instructions', () => {
         const ix = createInitializeAccount3Instruction(
             Keypair.generate().publicKey,
             Keypair.generate().publicKey,
-            Keypair.generate().publicKey
+            Keypair.generate().publicKey,
         );
         expect(ix.programId).to.eql(TOKEN_PROGRAM_ID);
         expect(ix.keys).to.have.length(2);
@@ -95,7 +95,7 @@ describe('spl-token-2022 instructions', () => {
             1,
             9,
             [],
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
         expect(ix.keys).to.have.length(4);
@@ -107,7 +107,7 @@ describe('spl-token-2022 instructions', () => {
             9,
             Keypair.generate().publicKey,
             null,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
         expect(ix.keys).to.have.length(2);
@@ -119,7 +119,7 @@ describe('spl-token-2022 instructions', () => {
             9,
             Keypair.generate().publicKey,
             null,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(ix.programId).to.eql(TOKEN_2022_PROGRAM_ID);
         expect(ix.keys).to.have.length(1);
@@ -162,7 +162,7 @@ describe('spl-associated-token-account instructions', () => {
             Keypair.generate().publicKey,
             Keypair.generate().publicKey,
             Keypair.generate().publicKey,
-            Keypair.generate().publicKey
+            Keypair.generate().publicKey,
         );
         expect(ix.programId).to.eql(ASSOCIATED_TOKEN_PROGRAM_ID);
         expect(ix.keys).to.have.length(6);
@@ -173,61 +173,61 @@ describe('state', () => {
     it('getAssociatedTokenAddress', async () => {
         const associatedPublicKey = await getAssociatedTokenAddress(
             new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
-            new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj')
+            new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj'),
         );
         expect(associatedPublicKey.toString()).to.eql(
-            new PublicKey('DShWnroshVbeUp28oopA3Pu7oFPDBtC1DBmPECXXAQ9n').toString()
+            new PublicKey('DShWnroshVbeUp28oopA3Pu7oFPDBtC1DBmPECXXAQ9n').toString(),
         );
         await expect(
             getAssociatedTokenAddress(
                 new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
-                associatedPublicKey
-            )
+                associatedPublicKey,
+            ),
         ).to.be.rejectedWith(TokenOwnerOffCurveError);
 
         const associatedPublicKey2 = await getAssociatedTokenAddress(
             new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
             associatedPublicKey,
-            true
+            true,
         );
         expect(associatedPublicKey2.toString()).to.eql(
-            new PublicKey('F3DmXZFqkfEWFA7MN2vDPs813GeEWPaT6nLk4PSGuWJd').toString()
+            new PublicKey('F3DmXZFqkfEWFA7MN2vDPs813GeEWPaT6nLk4PSGuWJd').toString(),
         );
     });
 
     it('getAssociatedTokenAddressSync matches getAssociatedTokenAddress', async () => {
         const asyncAssociatedPublicKey = await getAssociatedTokenAddress(
             new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
-            new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj')
+            new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj'),
         );
         const associatedPublicKey = getAssociatedTokenAddressSync(
             new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
-            new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj')
+            new PublicKey('B8UwBUUnKwCyKuGMbFKWaG7exYdDk2ozZrPg72NyVbfj'),
         );
         expect(associatedPublicKey.toString()).to.eql(
-            new PublicKey('DShWnroshVbeUp28oopA3Pu7oFPDBtC1DBmPECXXAQ9n').toString()
+            new PublicKey('DShWnroshVbeUp28oopA3Pu7oFPDBtC1DBmPECXXAQ9n').toString(),
         );
         expect(asyncAssociatedPublicKey.toString()).to.eql(associatedPublicKey.toString());
 
         expect(function () {
             getAssociatedTokenAddressSync(
                 new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
-                associatedPublicKey
+                associatedPublicKey,
             );
         }).to.throw(TokenOwnerOffCurveError);
 
         const asyncAssociatedPublicKey2 = await getAssociatedTokenAddress(
             new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
             asyncAssociatedPublicKey,
-            true
+            true,
         );
         const associatedPublicKey2 = getAssociatedTokenAddressSync(
             new PublicKey('7o36UsWR1JQLpZ9PE2gn9L4SQ69CNNiWAXd4Jt7rqz9Z'),
             associatedPublicKey,
-            true
+            true,
         );
         expect(associatedPublicKey2.toString()).to.eql(
-            new PublicKey('F3DmXZFqkfEWFA7MN2vDPs813GeEWPaT6nLk4PSGuWJd').toString()
+            new PublicKey('F3DmXZFqkfEWFA7MN2vDPs813GeEWPaT6nLk4PSGuWJd').toString(),
         );
         expect(asyncAssociatedPublicKey2.toString()).to.eql(associatedPublicKey2.toString());
     });
@@ -249,18 +249,18 @@ describe('extensionType', () => {
         expect(
             getMintLen([ExtensionType.TransferFeeConfig, ExtensionType.NonTransferable], {
                 [ExtensionType.TokenMetadata]: 200,
-            })
+            }),
         ).to.eql(486);
         expect(
             getMintLen([], {
                 [ExtensionType.TokenMetadata]: 200,
-            })
+            }),
         ).to.eql(370);
         // Should error on an extension that isn't variable-length
         expect(() =>
             getMintLen([ExtensionType.TransferFeeConfig, ExtensionType.NonTransferable], {
                 [ExtensionType.TransferHook]: 200,
-            })
+            }),
         ).to.throw('Extension 14 is not variable length');
     });
 

--- a/token/js/test/unit/metadataPointer.test.ts
+++ b/token/js/test/unit/metadataPointer.test.ts
@@ -21,7 +21,7 @@ describe('SPL Token 2022 MetadataPointer Extension', () => {
             mint,
             authority,
             metadataAddress,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_2022_PROGRAM_ID,
         );
         expect(instruction).to.deep.equal(
             new TransactionInstruction({
@@ -35,7 +35,7 @@ describe('SPL Token 2022 MetadataPointer Extension', () => {
                     AUTHORITY_ADDRESS_BYTES,
                     METADATA_ADDRESS_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can create UpdateMetadataPointerInstruction', () => {
@@ -57,7 +57,7 @@ describe('SPL Token 2022 MetadataPointer Extension', () => {
                     ]),
                     METADATA_ADDRESS_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can create UpdateMetadataPointerInstruction to none', () => {
@@ -79,7 +79,7 @@ describe('SPL Token 2022 MetadataPointer Extension', () => {
                     ]),
                     NULL_OPTIONAL_NONZERO_PUBKEY_BYTES,
                 ]),
-            })
+            }),
         );
     });
     it('can get state with authority and metadata address', async () => {

--- a/token/js/test/unit/tokenMetadata.test.ts
+++ b/token/js/test/unit/tokenMetadata.test.ts
@@ -20,10 +20,10 @@ describe('SPL Token 2022 Metadata Extension', () => {
             } as TokenMetadata);
 
             expect(() => updateTokenMetadata(input, 'mint', 'string')).to.throw(
-                'Cannot update mint via this instruction'
+                'Cannot update mint via this instruction',
             );
             expect(() => updateTokenMetadata(input, 'updateAuthority', 'string')).to.throw(
-                'Cannot update updateAuthority via this instruction'
+                'Cannot update updateAuthority via this instruction',
             );
         });
         it('can update name', async () => {

--- a/token/js/test/unit/transferHook.test.ts
+++ b/token/js/test/unit/transferHook.test.ts
@@ -117,7 +117,7 @@ describe('transferHook', () => {
             connection = await getConnection();
             connection.getAccountInfo = async (
                 _publicKey: PublicKey,
-                _commitmentOrConfig?: Parameters<(typeof connection)['getAccountInfo']>[1]
+                _commitmentOrConfig?: Parameters<(typeof connection)['getAccountInfo']>[1],
             ): ReturnType<(typeof connection)['getAccountInfo']> => ({
                 data: Buffer.from([0, 0, 2, 2, 2, 2]),
                 owner: PublicKey.default,
@@ -166,7 +166,7 @@ describe('transferHook', () => {
                 plainExtraAccountMeta,
                 [],
                 instructionData,
-                testProgramId
+                testProgramId,
             );
 
             expect(resolvedPlainAccount.pubkey).to.eql(plainAccount);
@@ -178,7 +178,7 @@ describe('transferHook', () => {
                 pdaExtraAccountMeta,
                 [resolvedPlainAccount],
                 instructionData,
-                testProgramId
+                testProgramId,
             );
 
             expect(resolvedPdaAccount.pubkey).to.eql(pdaPublicKey);
@@ -190,7 +190,7 @@ describe('transferHook', () => {
                 pdaExtraAccountMetaWithProgramId,
                 [resolvedPlainAccount],
                 instructionData,
-                testProgramId
+                testProgramId,
             );
 
             expect(resolvedPdaAccountWithProgramId.pubkey).to.eql(pdaPublicKeyWithProgramId);
@@ -235,12 +235,12 @@ describe('transferHook', () => {
         function createMockFetchAccountDataFn(extraAccounts: ExtraAccountMeta[]) {
             return async function mockFetchAccountDataFn(
                 publicKey: PublicKey,
-                _commitmentOrConfig?: Parameters<Connection['getAccountInfo']>[1]
+                _commitmentOrConfig?: Parameters<Connection['getAccountInfo']>[1],
             ): ReturnType<Connection['getAccountInfo']> {
                 // Mocked mint state
                 if (publicKey.equals(mintPubkey)) {
                     const data = Buffer.alloc(
-                        ACCOUNT_SIZE + ACCOUNT_TYPE_SIZE + TYPE_SIZE + LENGTH_SIZE + TRANSFER_HOOK_SIZE
+                        ACCOUNT_SIZE + ACCOUNT_TYPE_SIZE + TYPE_SIZE + LENGTH_SIZE + TRANSFER_HOOK_SIZE,
                     );
                     MintLayout.encode(
                         {
@@ -253,7 +253,7 @@ describe('transferHook', () => {
                             freezeAuthority: PublicKey.default,
                         },
                         data,
-                        0
+                        0,
                     );
                     data.writeUint8(1, ACCOUNT_SIZE); // Account type (1): Mint = 1
                     data.writeUint16LE(ExtensionType.TransferHook, ACCOUNT_SIZE + ACCOUNT_TYPE_SIZE);
@@ -264,7 +264,7 @@ describe('transferHook', () => {
                             programId: transferHookProgramId,
                         },
                         data,
-                        ACCOUNT_SIZE + ACCOUNT_TYPE_SIZE + TYPE_SIZE + LENGTH_SIZE
+                        ACCOUNT_SIZE + ACCOUNT_TYPE_SIZE + TYPE_SIZE + LENGTH_SIZE,
                     );
                     return {
                         data,
@@ -290,7 +290,7 @@ describe('transferHook', () => {
                             length: 4 + ExtraAccountMetaLayout.span * extraAccounts.length,
                             extraAccountsList,
                         },
-                        data
+                        data,
                     );
                     return {
                         data,
@@ -362,18 +362,18 @@ describe('transferHook', () => {
 
             const extraMeta4Pubkey = PublicKey.findProgramAddressSync(
                 [sourcePubkey.toBuffer(), validateStatePubkey.toBuffer()],
-                transferHookProgramId
+                transferHookProgramId,
             )[0];
             const extraMeta5Pubkey = PublicKey.findProgramAddressSync(
                 [extraMeta1Pubkey.toBuffer(), extraMeta2Pubkey.toBuffer()],
-                transferHookProgramId
+                transferHookProgramId,
             )[0];
             const extraMeta6Pubkey = PublicKey.findProgramAddressSync(
                 [
                     Buffer.from('prefix'),
                     amountInLeBytes, // Instruction data 8..16
                 ],
-                transferHookProgramId
+                transferHookProgramId,
             )[0];
 
             // Fail missing key
@@ -395,8 +395,8 @@ describe('transferHook', () => {
                     mintPubkey,
                     destinationPubkey,
                     authorityPubkey,
-                    amount
-                )
+                    amount,
+                ),
             ).to.be.rejectedWith('Missing required account in instruction');
 
             const instruction = new TransactionInstruction({
@@ -417,7 +417,7 @@ describe('transferHook', () => {
                 mintPubkey,
                 destinationPubkey,
                 authorityPubkey,
-                amount
+                amount,
             );
 
             const checkMetas = [
@@ -472,20 +472,20 @@ describe('transferHook', () => {
                     sourcePubkey.toBuffer(), // Account key at index 0
                     mintPubkey.toBuffer(), // Account key at index 1
                 ],
-                transferHookProgramId
+                transferHookProgramId,
             )[0];
             const extraMeta2Pubkey = PublicKey.findProgramAddressSync(
                 [
                     validateStatePubkey.toBuffer(), // Account key at index 4
                 ],
-                transferHookProgramId
+                transferHookProgramId,
             )[0];
             const extraMeta3Pubkey = PublicKey.findProgramAddressSync(
                 [
                     Buffer.from('prefix'),
                     amountInLeBytes, // Instruction data 8..16
                 ],
-                transferHookProgramId
+                transferHookProgramId,
             )[0];
             const extraMeta4Pubkey = arbitraryProgramId;
             const extraMeta5Pubkey = PublicKey.findProgramAddressSync(
@@ -494,7 +494,7 @@ describe('transferHook', () => {
                     amountInLeBytes, // Instruction data 8..16
                     extraMeta2Pubkey.toBuffer(),
                 ],
-                extraMeta4Pubkey // PDA off of the arbitrary program ID
+                extraMeta4Pubkey, // PDA off of the arbitrary program ID
             )[0];
             const extraMeta6Pubkey = PublicKey.findProgramAddressSync(
                 [
@@ -503,7 +503,7 @@ describe('transferHook', () => {
                     extraMeta2Pubkey.toBuffer(),
                     extraMeta5Pubkey.toBuffer(),
                 ],
-                extraMeta4Pubkey // PDA off of the arbitrary program ID
+                extraMeta4Pubkey, // PDA off of the arbitrary program ID
             )[0];
 
             const instruction = await createTransferCheckedWithTransferHookInstruction(
@@ -516,7 +516,7 @@ describe('transferHook', () => {
                 decimals,
                 [],
                 undefined,
-                TOKEN_2022_PROGRAM_ID
+                TOKEN_2022_PROGRAM_ID,
             );
 
             const checkMetas = [

--- a/token/js/test/unit/transferfee.test.ts
+++ b/token/js/test/unit/transferfee.test.ts
@@ -19,7 +19,7 @@ describe('transferFee', () => {
                 transferFeeConfigAuthority,
                 withdrawWithheldAuthority,
                 100,
-                100n
+                100n,
             );
             const decoded = decodeInitializeTransferFeeConfigInstructionUnchecked(instruction);
             expect(decoded.data.transferFeeConfigAuthority).to.eql(transferFeeConfigAuthority);
@@ -35,7 +35,7 @@ describe('transferFee', () => {
                 null,
                 withdrawWithheldAuthority,
                 100,
-                100n
+                100n,
             );
             const decoded = decodeInitializeTransferFeeConfigInstructionUnchecked(instruction);
             expect(decoded.data.transferFeeConfigAuthority).to.eql(null);
@@ -51,7 +51,7 @@ describe('transferFee', () => {
                 transferFeeConfigAuthority,
                 null,
                 100,
-                100n
+                100n,
             );
             const decoded = decodeInitializeTransferFeeConfigInstructionUnchecked(instruction);
             expect(decoded.data.transferFeeConfigAuthority).to.eql(transferFeeConfigAuthority);


### PR DESCRIPTION
#### Problem

There are different prettier configurations all over the repo, but we
use pnpm to manage the workspace of JS packages.

#### Solution

Unify the prettier configurations to one top-level configuration