### PR TITLE
Adding Curve Option When Creating ATA

### DIFF
--- a/token/js/src/actions/createAssociatedTokenAccount.ts
+++ b/token/js/src/actions/createAssociatedTokenAccount.ts
@@ -28,7 +28,13 @@ export async function createAssociatedTokenAccount(
     associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
     allowOwnerOffCurve = false,
 ): Promise<PublicKey> {
-    const associatedToken = getAssociatedTokenAddressSync(mint, owner, allowOwnerOffCurve, programId, associatedTokenProgramId);
+    const associatedToken = getAssociatedTokenAddressSync(
+        mint,
+        owner,
+        allowOwnerOffCurve,
+        programId,
+        associatedTokenProgramId,
+    );
 
     const transaction = new Transaction().add(
         createAssociatedTokenAccountInstruction(

--- a/token/js/src/actions/createAssociatedTokenAccount.ts
+++ b/token/js/src/actions/createAssociatedTokenAccount.ts
@@ -14,6 +14,7 @@ import { getAssociatedTokenAddressSync } from '../state/mint.js';
  * @param confirmOptions           Options for confirming the transaction
  * @param programId                SPL Token program account
  * @param associatedTokenProgramId SPL Associated Token program account
+ * @param allowOwnerOffCurve       Allow the owner account to be a PDA (Program Derived Address)
  *
  * @return Address of the new associated token account
  */
@@ -25,8 +26,9 @@ export async function createAssociatedTokenAccount(
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
     associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
+    allowOwnerOffCurve = false,
 ): Promise<PublicKey> {
-    const associatedToken = getAssociatedTokenAddressSync(mint, owner, false, programId, associatedTokenProgramId);
+    const associatedToken = getAssociatedTokenAddressSync(mint, owner, allowOwnerOffCurve, programId, associatedTokenProgramId);
 
     const transaction = new Transaction().add(
         createAssociatedTokenAccountInstruction(


### PR DESCRIPTION
### Problem
In certain scenarios, such as with a DEX, it may be necessary to create an associated token account for a PDA (Program Derived Address). However, the current implementation of `createAssociatedTokenAccount` in the `@solana/spl-token` library has the `allowOffCurve` option set to false by default while `getAssociatedTokenAddressSync`.
(Reference: [GitHub link](https://github.com/solana-labs/solana-program-library/blob/master/token/js/src/actions/createAssociatedTokenAccount.ts#L29))

To create an ATA for a PDA, a custom implementation is required.

### Solution
This PR aims to enhance code reusability by allowing users to set the `allowOffCurve` option when using `createAssociatedTokenAccount`.