### PR TITLE
Add tagging automation for crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on push:
+  branches:
+    - master
+  paths-ignore:
+    - 'docs/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Create tags
+        id: create_tags
+        run: |
+          ci/tag-new-crates.sh
+          git push --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/detect-changed-manifests.sh
+++ b/ci/detect-changed-manifests.sh
@@ -1,0 +1,25 @@
+# Source this file.
+#
+# Detects any manifests whose versions have changed.
+# Does so by comparing the current version in the Cargo.toml with the previous
+# version in the last commit. Intended for squash-merged PRs.
+
+detect_changed_manifests() {
+  local changed_manifests=()
+  local cargo_toml_files=$(find . -name "Cargo.toml")
+
+  for file in $cargo_toml_files; do
+    # Get the current version from the manifest.
+    local current_version=$(grep -E '^version\s*=' "$file" | sed -E 's/version\s*=\s*"(.*)"/\1/')
+
+    # Get the previous version from the last commit.
+    local previous_version=$(git show HEAD~1:"$file" | grep -E '^version\s*=' | sed -E 's/version\s*=\s*"(.*)"/\1/' 2>/dev/null)
+
+    # Compare the versions and add the path to the list if they are different.
+    if [ "$current_version" != "$previous_version" ]; then
+      changed_manifests+=("$file")
+    fi
+  done
+
+  echo "${changed_manifests[@]}"
+}

--- a/ci/tag-releases.sh
+++ b/ci/tag-releases.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Creates a new git tag for each package that has a new version.
+
+set -e
+
+source ci/detect-changed-manifests.sh
+
+changed_manifests=$(detect_changed_manifests)
+
+if [ -n "$changed_manifests" ]; then
+  for manifest_path in $changed_manifests; do
+    # Read the package name and version from its manifest.
+    package_name=$(grep '^name\s*=' "$manifest_path" | awk -F'\"' '{print $2}')
+    new_version=$(grep '^version\s*=' "$manifest_path" | awk -F'\"' '{print $2}')
+
+    # Create a new git tag.
+    tag_name="${package_name}-v${new_version}"
+    git tag "$tag_name"
+    echo "Created tag: $tag_name"
+  done
+else
+  echo "No versions changed."
+fi


### PR DESCRIPTION
#### Problem
Whenever we increment versions for crates in SPL, we have to remember to manually create tags for these new packages on the repository, and commit those tags to the remote. It would be nice if this was just a part of CI.

#### Summary of Changes
Add two new scripts and a GitHub action:

- `ci/detect-changed-manifests.sh`: Detects changes to a manifest's version and returns a list of all manifests whose version changed.
- `ci/tag-releases.sh`: Creates a new Git tag for each changed manifest.
- `workflows/release.yml`: Workflow for `master` to create new tags and commit them to the repository whenever manifest versions change in a merged PR.