### PR TITLE
Add check withdraw-withheld-tokens has sources or include mint

### DIFF
--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -2271,6 +2271,13 @@ pub fn app<'a, 'b>(
                 )
                 .arg(owner_address_arg())
                 .arg(multisig_signer_arg())
+                .group(
+                    ArgGroup::with_name("source_or_mint")
+                        .arg("source")
+                        .arg("include_mint")
+                        .multiple(true)
+                        .required(true)
+                )
         )
         .subcommand(
             SubCommand::with_name(CommandName::SetTransferFee.into())


### PR DESCRIPTION
Just check both conditions and return error. Clap doesn't have the method for check that, so I do check in command logic.
Fixes #7042 