### PR TITLE
[token-cli] Add support for transfer-hook account resolution for transfers with the transfer-fee extension.

### DIFF
--- a/token/program-2022-test/tests/transfer_hook.rs
+++ b/token/program-2022-test/tests/transfer_hook.rs
@@ -356,25 +356,6 @@ async fn setup_with_fee(mint: Keypair, program_id: &Pubkey, authority: &Pubkey) 
     context
 }
 
-fn test_transfer_fee() -> TransferFee {
-    TransferFee {
-        epoch: 0.into(),
-        transfer_fee_basis_points: TEST_FEE_BASIS_POINTS.into(),
-        maximum_fee: TEST_MAXIMUM_FEE.into(),
-    }
-}
-
-fn test_transfer_fee_config() -> TransferFeeConfig {
-    let transfer_fee = test_transfer_fee();
-    TransferFeeConfig {
-        transfer_fee_config_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
-        withdraw_withheld_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
-        withheld_amount: 0.into(),
-        older_transfer_fee: transfer_fee,
-        newer_transfer_fee: transfer_fee,
-    }
-}
-
 async fn setup_with_confidential_transfers(
     mint: Keypair,
     program_id: &Pubkey,
@@ -682,7 +663,18 @@ async fn success_transfer_with_fee() {
     let (alice_account, bob_account) =
         setup_accounts(&token_context, Keypair::new(), Keypair::new(), alice_amount).await;
 
-    let transfer_fee_config = test_transfer_fee_config();
+    let transfer_fee = TransferFee {
+        epoch: 0.into(),
+        transfer_fee_basis_points: TEST_FEE_BASIS_POINTS.into(),
+        maximum_fee: TEST_MAXIMUM_FEE.into(),
+    };
+    let transfer_fee_config = TransferFeeConfig {
+        transfer_fee_config_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
+        withdraw_withheld_authority: COption::Some(Pubkey::new_unique()).try_into().unwrap(),
+        withheld_amount: 0.into(),
+        older_transfer_fee: transfer_fee,
+        newer_transfer_fee: transfer_fee,
+    };
     let fee = transfer_fee_config
         .calculate_epoch_fee(0, transfer_amount)
         .unwrap();

--- a/token/program-2022/src/offchain.rs
+++ b/token/program-2022/src/offchain.rs
@@ -3,7 +3,7 @@
 pub use spl_transfer_hook_interface::offchain::{AccountDataResult, AccountFetchError};
 use {
     crate::{
-        extension::{transfer_hook, StateWithExtensions},
+        extension::{transfer_fee, transfer_hook, StateWithExtensions},
         state::Mint,
     },
     solana_program::{instruction::Instruction, program_error::ProgramError, pubkey::Pubkey},

--- a/token/program-2022/src/offchain.rs
+++ b/token/program-2022/src/offchain.rs
@@ -74,6 +74,72 @@ where
     Ok(transfer_instruction)
 }
 
+/// Offchain helper to create a `TransferCheckedWithFee` instruction with all
+/// additional required account metas for a transfer, including the ones
+/// required by the transfer hook.
+///
+/// To be client-agnostic and to avoid pulling in the full solana-sdk, this
+/// simply takes a function that will return its data as `Future<Vec<u8>>` for
+/// the given address. Can be called in the following way:
+///
+/// ```rust,ignore
+/// let instruction = create_transfer_checked_with_fee_instruction_with_extra_metas(
+///     &spl_token_2022::id(),
+///     &source,
+///     &mint,
+///     &destination,
+///     &authority,
+///     &[],
+///     amount,
+///     decimals,
+///     fee,
+///     |address| self.client.get_account(&address).map_ok(|opt| opt.map(|acc| acc.data)),
+/// )
+/// .await?
+/// ```
+#[allow(clippy::too_many_arguments)]
+pub async fn create_transfer_checked_with_fee_instruction_with_extra_metas<F, Fut>(
+    token_program_id: &Pubkey,
+    source_pubkey: &Pubkey,
+    mint_pubkey: &Pubkey,
+    destination_pubkey: &Pubkey,
+    authority_pubkey: &Pubkey,
+    signer_pubkeys: &[&Pubkey],
+    amount: u64,
+    decimals: u8,
+    fee: u64,
+    fetch_account_data_fn: F,
+) -> Result<Instruction, AccountFetchError>
+where
+    F: Fn(Pubkey) -> Fut,
+    Fut: Future<Output = AccountDataResult>,
+{
+    let mut transfer_instruction = transfer_fee::instruction::transfer_checked_with_fee(
+        token_program_id,
+        source_pubkey,
+        mint_pubkey,
+        destination_pubkey,
+        authority_pubkey,
+        signer_pubkeys,
+        amount,
+        decimals,
+        fee,
+    )?;
+
+    add_extra_account_metas(
+        &mut transfer_instruction,
+        source_pubkey,
+        mint_pubkey,
+        destination_pubkey,
+        authority_pubkey,
+        amount,
+        fetch_account_data_fn,
+    )
+    .await?;
+
+    Ok(transfer_instruction)
+}
+
 /// Offchain helper to add required account metas to an instruction, including
 /// the ones required by the transfer hook.
 ///

--- a/token/program-2022/src/onchain.rs
+++ b/token/program-2022/src/onchain.rs
@@ -80,7 +80,8 @@ pub fn invoke_transfer_checked<'a>(
 }
 
 /// Helper to CPI into token-2022 on-chain, looking through the additional
-/// account infos to create the proper instruction with the proper account infos
+/// account infos to create the proper instruction with the fee
+/// and proper account infos
 #[allow(clippy::too_many_arguments)]
 pub fn invoke_transfer_checked_with_fee<'a>(
     token_program_id: &Pubkey,

--- a/token/program-2022/src/onchain.rs
+++ b/token/program-2022/src/onchain.rs
@@ -3,7 +3,7 @@
 
 use {
     crate::{
-        extension::{transfer_hook, StateWithExtensions},
+        extension::{transfer_fee, transfer_hook, StateWithExtensions},
         instruction,
         state::Mint,
     },
@@ -37,6 +37,73 @@ pub fn invoke_transfer_checked<'a>(
         &[], // add them later, to avoid unnecessary clones
         amount,
         decimals,
+    )?;
+
+    let mut cpi_account_infos = vec![
+        source_info.clone(),
+        mint_info.clone(),
+        destination_info.clone(),
+        authority_info.clone(),
+    ];
+
+    // if it's a signer, it might be a multisig signer, throw it in!
+    additional_accounts
+        .iter()
+        .filter(|ai| ai.is_signer)
+        .for_each(|ai| {
+            cpi_account_infos.push(ai.clone());
+            cpi_instruction
+                .accounts
+                .push(AccountMeta::new_readonly(*ai.key, ai.is_signer));
+        });
+
+    // scope the borrowing to avoid a double-borrow during CPI
+    {
+        let mint_data = mint_info.try_borrow_data()?;
+        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
+        if let Some(program_id) = transfer_hook::get_program_id(&mint) {
+            add_extra_accounts_for_execute_cpi(
+                &mut cpi_instruction,
+                &mut cpi_account_infos,
+                &program_id,
+                source_info,
+                mint_info.clone(),
+                destination_info,
+                authority_info,
+                amount,
+                additional_accounts,
+            )?;
+        }
+    }
+
+    invoke_signed(&cpi_instruction, &cpi_account_infos, seeds)
+}
+
+/// Helper to CPI into token-2022 on-chain, looking through the additional
+/// account infos to create the proper instruction with the proper account infos
+#[allow(clippy::too_many_arguments)]
+pub fn invoke_transfer_checked_with_fee<'a>(
+    token_program_id: &Pubkey,
+    source_info: AccountInfo<'a>,
+    mint_info: AccountInfo<'a>,
+    destination_info: AccountInfo<'a>,
+    authority_info: AccountInfo<'a>,
+    additional_accounts: &[AccountInfo<'a>],
+    amount: u64,
+    decimals: u8,
+    fee: u64,
+    seeds: &[&[&[u8]]],
+) -> ProgramResult {
+    let mut cpi_instruction = transfer_fee::instruction::transfer_checked_with_fee(
+        token_program_id,
+        source_info.key,
+        mint_info.key,
+        destination_info.key,
+        authority_info.key,
+        &[], // add them later, to avoid unnecessary clones
+        amount,
+        decimals,
+        fee,
     )?;
 
     let mut cpi_account_infos = vec![


### PR DESCRIPTION
Per #7059 

Adds a new offchain helper `offchain::create_transfer_checked_with_fee_instruction_with_extra_metas`.
Adds a new onchain helper `onchain::invoke_transfer_checked_with_fee`

Adds logic to `transfer_with_fee` in token/client/src/token.rs to add the extra-account-metas using the offchain helper if the token uses the transfer-hook extension. 
