### PR TITLE
[token-client] Make `close_context_state_account` and `close_record_account` variable order consistent

### DIFF
--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -1662,19 +1662,19 @@ async fn command_transfer(
             // close context state accounts
             let close_context_state_signer = &[&context_state_authority];
             let _ = try_join!(
-                token.confidential_transfer_close_context_state(
+                token.confidential_transfer_close_context_state_account(
                     &equality_proof_pubkey,
                     &sender,
                     &context_state_authority_pubkey,
                     close_context_state_signer
                 ),
-                token.confidential_transfer_close_context_state(
+                token.confidential_transfer_close_context_state_account(
                     &ciphertext_validity_proof_pubkey,
                     &sender,
                     &context_state_authority_pubkey,
                     close_context_state_signer
                 ),
-                token.confidential_transfer_close_context_state(
+                token.confidential_transfer_close_context_state_account(
                     &range_proof_pubkey,
                     &sender,
                     &context_state_authority_pubkey,
@@ -3402,13 +3402,13 @@ async fn command_deposit_withdraw_confidential_tokens(
             // close context state account
             let close_context_state_signer = &[&context_state_authority];
             let _ = try_join!(
-                token.confidential_transfer_close_context_state(
+                token.confidential_transfer_close_context_state_account(
                     &equality_proof_context_state_pubkey,
                     &token_account_address,
                     &context_state_authority_pubkey,
                     close_context_state_signer
                 ),
-                token.confidential_transfer_close_context_state(
+                token.confidential_transfer_close_context_state_account(
                     &range_proof_context_state_pubkey,
                     &token_account_address,
                     &context_state_authority_pubkey,

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2355,15 +2355,15 @@ where
     pub async fn confidential_transfer_close_record_account<S: Signers>(
         &self,
         record_account: &Pubkey,
-        record_authority: &Pubkey,
-        receiver: &Pubkey,
+        lamport_destination_account: &Pubkey,
+        record_account_authority: &Pubkey,
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         self.process_ixs(
             &[spl_record::instruction::close_account(
                 record_account,
-                record_authority,
-                receiver,
+                record_account_authority,
+                lamport_destination_account,
             )],
             signing_keypairs,
         )

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -2448,7 +2448,7 @@ where
     }
 
     /// Close a ZK Token proof program context state
-    pub async fn confidential_transfer_close_context_state<S: Signers>(
+    pub async fn confidential_transfer_close_context_state_account<S: Signers>(
         &self,
         context_state_account: &Pubkey,
         lamport_destination_account: &Pubkey,

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -152,7 +152,7 @@ async fn configure_account_with_option<S: Signers>(
                 .await;
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &pubkey_validity_proof_context_account.pubkey(),
                     account,
                     &context_account_authority.pubkey(),
@@ -685,7 +685,7 @@ async fn empty_account_with_option<S: Signers>(
                 .await;
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &zero_ciphertext_proof_context_account.pubkey(),
                     account,
                     &context_account_authority.pubkey(),
@@ -1135,7 +1135,7 @@ async fn withdraw_with_option<S: Signers>(
                 .await;
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &equality_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -1145,7 +1145,7 @@ async fn withdraw_with_option<S: Signers>(
                 .unwrap();
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &range_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -1548,7 +1548,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                 .await;
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &equality_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -1558,7 +1558,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                 .unwrap();
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &ciphertext_validity_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -1568,7 +1568,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                 .unwrap();
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &range_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -2209,7 +2209,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                 .await;
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &equality_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -2219,7 +2219,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                 .unwrap();
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &transfer_amount_ciphertext_validity_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -2229,7 +2229,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                 .unwrap();
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &percentage_with_cap_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -2239,7 +2239,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                 .unwrap();
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &fee_ciphertext_validity_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
@@ -2249,7 +2249,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                 .unwrap();
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &range_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -110,8 +110,8 @@ async fn configure_account_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &pubkey_validity_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -637,8 +637,8 @@ async fn empty_account_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &zero_ciphertext_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -1054,8 +1054,8 @@ async fn withdraw_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &equality_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -1064,8 +1064,8 @@ async fn withdraw_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &range_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -1426,8 +1426,8 @@ async fn confidential_transfer_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &equality_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -1436,8 +1436,8 @@ async fn confidential_transfer_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &ciphertext_validity_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -1446,8 +1446,8 @@ async fn confidential_transfer_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &range_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -2024,8 +2024,8 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &equality_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -2034,8 +2034,8 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &transfer_amount_ciphertext_validity_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -2044,8 +2044,8 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &fee_sigma_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -2054,8 +2054,8 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &fee_ciphertext_validity_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -2064,8 +2064,8 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &range_proof_record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     source_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -587,7 +587,7 @@ async fn withdraw_withheld_tokens_from_mint_with_option<S: Signers>(
                 .await;
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &context_account.pubkey(),
                     destination_account,
                     &context_account_authority.pubkey(),
@@ -913,7 +913,7 @@ async fn withdraw_withheld_tokens_from_accounts_with_option<S: Signers>(
                 .await;
 
             token
-                .confidential_transfer_close_context_state(
+                .confidential_transfer_close_context_state_account(
                     &context_account.pubkey(),
                     destination_account,
                     &context_account_authority.pubkey(),

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -534,8 +534,8 @@ async fn withdraw_withheld_tokens_from_mint_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     destination_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await
@@ -859,8 +859,8 @@ async fn withdraw_withheld_tokens_from_accounts_with_option<S: Signers>(
             token
                 .confidential_transfer_close_record_account(
                     &record_account.pubkey(),
-                    &record_account_authority.pubkey(),
                     destination_account,
+                    &record_account_authority.pubkey(),
                     &[&record_account_authority],
                 )
                 .await


### PR DESCRIPTION
#### Problem
There is an inconsistency in the parameter orders between the `confidential_transfer_close_context_state` and `confidential_transfer_close_record_account` functions.
- In `confidential_transfer_close_context_state`, the lamport destination account is before the context state authority
- In `confidential_transfer_close_record_account`, the lamport destination comes after the context state authority

#### Summary of Changes
I updated `confidential_transfer_close_record_account` function to follow the `confidential_transfer_close_context_state` function. I also updated the `confidential_transfer_close_context_state` function name to `confidential_transfer_close_context_state_account` to be more consistent with the other functions.