### PR TITLE
[token-client] use `Signers`instead of `Signer` for confidential transfer client functions

### DIFF
--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -1604,27 +1604,32 @@ async fn command_transfer(
                 .unwrap();
 
             // setup proofs
+            let create_range_proof_context_signer = &[&range_proof_context_state_account];
+            let create_equality_proof_context_signer = &[&equality_proof_context_state_account];
+            let create_ciphertext_validity_proof_context_signer =
+                &[&ciphertext_validity_proof_context_state_account];
+
             let _ = try_join!(
                 token.confidential_transfer_create_context_state_account(
                     &range_proof_pubkey,
                     &context_state_authority_pubkey,
                     &range_proof_data,
                     true,
-                    &range_proof_context_state_account,
+                    create_range_proof_context_signer
                 ),
                 token.confidential_transfer_create_context_state_account(
                     &equality_proof_pubkey,
                     &context_state_authority_pubkey,
                     &equality_proof_data,
                     false,
-                    &equality_proof_context_state_account,
+                    create_equality_proof_context_signer
                 ),
                 token.confidential_transfer_create_context_state_account(
                     &ciphertext_validity_proof_pubkey,
                     &context_state_authority_pubkey,
                     &ciphertext_validity_proof_data,
                     false,
-                    &ciphertext_validity_proof_context_state_account,
+                    create_ciphertext_validity_proof_context_signer
                 )
             )?;
 
@@ -1655,24 +1660,25 @@ async fn command_transfer(
                 .await?;
 
             // close context state accounts
+            let close_context_state_signer = &[&context_state_authority];
             let _ = try_join!(
                 token.confidential_transfer_close_context_state(
                     &equality_proof_pubkey,
                     &sender,
                     &context_state_authority_pubkey,
-                    &context_state_authority,
+                    close_context_state_signer
                 ),
                 token.confidential_transfer_close_context_state(
                     &ciphertext_validity_proof_pubkey,
                     &sender,
                     &context_state_authority_pubkey,
-                    &context_state_authority,
+                    close_context_state_signer
                 ),
                 token.confidential_transfer_close_context_state(
                     &range_proof_pubkey,
                     &sender,
                     &context_state_authority_pubkey,
-                    &context_state_authority,
+                    close_context_state_signer
                 ),
             )?;
 
@@ -3353,6 +3359,8 @@ async fn command_deposit_withdraw_confidential_tokens(
 
             // set up context state accounts
             let context_state_authority_pubkey = context_state_authority.pubkey();
+            let create_equality_proof_signer = &[&equality_proof_context_state_keypair];
+            let create_range_proof_signer = &[&range_proof_context_state_keypair];
 
             let _ = try_join!(
                 token.confidential_transfer_create_context_state_account(
@@ -3360,14 +3368,14 @@ async fn command_deposit_withdraw_confidential_tokens(
                     &context_state_authority_pubkey,
                     &equality_proof_data,
                     false,
-                    &equality_proof_context_state_keypair,
+                    create_equality_proof_signer
                 ),
                 token.confidential_transfer_create_context_state_account(
                     &range_proof_context_state_pubkey,
                     &context_state_authority_pubkey,
                     &range_proof_data,
                     true,
-                    &range_proof_context_state_keypair,
+                    create_range_proof_signer,
                 )
             )?;
 
@@ -3392,18 +3400,19 @@ async fn command_deposit_withdraw_confidential_tokens(
                 .await?;
 
             // close context state account
+            let close_context_state_signer = &[&context_state_authority];
             let _ = try_join!(
                 token.confidential_transfer_close_context_state(
                     &equality_proof_context_state_pubkey,
                     &token_account_address,
                     &context_state_authority_pubkey,
-                    &context_state_authority,
+                    close_context_state_signer
                 ),
                 token.confidential_transfer_close_context_state(
                     &range_proof_context_state_pubkey,
                     &token_account_address,
                     &context_state_authority_pubkey,
-                    &context_state_authority,
+                    close_context_state_signer
                 )
             )?;
 

--- a/token/program-2022-test/tests/confidential_transfer.rs
+++ b/token/program-2022-test/tests/confidential_transfer.rs
@@ -112,7 +112,7 @@ async fn configure_account_with_option<S: Signers>(
                     &pubkey_validity_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -131,7 +131,7 @@ async fn configure_account_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &pubkey_validity_proof_data,
                     false,
-                    &pubkey_validity_proof_context_account,
+                    &[&pubkey_validity_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -156,7 +156,7 @@ async fn configure_account_with_option<S: Signers>(
                     &pubkey_validity_proof_context_account.pubkey(),
                     account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -639,7 +639,7 @@ async fn empty_account_with_option<S: Signers>(
                     &zero_ciphertext_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -665,7 +665,7 @@ async fn empty_account_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &zero_ciphertext_proof_data,
                     false,
-                    &zero_ciphertext_proof_context_account,
+                    &[&zero_ciphertext_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -689,7 +689,7 @@ async fn empty_account_with_option<S: Signers>(
                     &zero_ciphertext_proof_context_account.pubkey(),
                     account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1056,7 +1056,7 @@ async fn withdraw_with_option<S: Signers>(
                     &equality_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1066,7 +1066,7 @@ async fn withdraw_with_option<S: Signers>(
                     &range_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1097,7 +1097,7 @@ async fn withdraw_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
                     false,
-                    &equality_proof_context_account,
+                    &[&equality_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -1111,7 +1111,7 @@ async fn withdraw_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &range_proof_data,
                     false,
-                    &range_proof_context_account,
+                    &[&range_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -1139,7 +1139,7 @@ async fn withdraw_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1149,7 +1149,7 @@ async fn withdraw_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1428,7 +1428,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &equality_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1438,7 +1438,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &ciphertext_validity_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1448,7 +1448,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &range_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1487,7 +1487,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
                     false,
-                    &equality_proof_context_account,
+                    &[&equality_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -1501,7 +1501,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &ciphertext_validity_proof_data,
                     false,
-                    &ciphertext_validity_proof_context_account,
+                    &[&ciphertext_validity_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -1515,7 +1515,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &range_proof_data,
                     false,
-                    &range_proof_context_account,
+                    &[&range_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -1552,7 +1552,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1562,7 +1562,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &ciphertext_validity_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -1572,7 +1572,7 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2026,7 +2026,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &equality_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2036,7 +2036,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &transfer_amount_ciphertext_validity_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2046,7 +2046,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &fee_sigma_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2056,7 +2056,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &fee_ciphertext_validity_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2066,7 +2066,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &range_proof_record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     source_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2112,7 +2112,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
                     false,
-                    &equality_proof_context_account,
+                    &[&equality_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -2126,7 +2126,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &transfer_amount_ciphertext_validity_proof_data,
                     false,
-                    &transfer_amount_ciphertext_validity_proof_context_account,
+                    &[&transfer_amount_ciphertext_validity_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -2142,7 +2142,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &percentage_with_cap_proof_data,
                     false,
-                    &percentage_with_cap_proof_context_account,
+                    &[&percentage_with_cap_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -2156,7 +2156,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &fee_ciphertext_validity_proof_data,
                     false,
-                    &fee_ciphertext_validity_proof_context_account,
+                    &[&fee_ciphertext_validity_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -2171,7 +2171,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &range_proof_data,
                     false,
-                    &range_proof_context_account,
+                    &[&range_proof_context_account],
                 )
                 .await
                 .unwrap();
@@ -2213,7 +2213,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2223,7 +2223,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &transfer_amount_ciphertext_validity_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2233,7 +2233,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &percentage_with_cap_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2243,7 +2243,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &fee_ciphertext_validity_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -2253,7 +2253,7 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     source_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();

--- a/token/program-2022-test/tests/confidential_transfer_fee.rs
+++ b/token/program-2022-test/tests/confidential_transfer_fee.rs
@@ -536,7 +536,7 @@ async fn withdraw_withheld_tokens_from_mint_with_option<S: Signers>(
                     &record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     destination_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -566,7 +566,7 @@ async fn withdraw_withheld_tokens_from_mint_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &equality_proof,
                     false,
-                    &context_account,
+                    &[&context_account],
                 )
                 .await
                 .unwrap();
@@ -591,7 +591,7 @@ async fn withdraw_withheld_tokens_from_mint_with_option<S: Signers>(
                     &context_account.pubkey(),
                     destination_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();
@@ -861,7 +861,7 @@ async fn withdraw_withheld_tokens_from_accounts_with_option<S: Signers>(
                     &record_account.pubkey(),
                     &record_account_authority.pubkey(),
                     destination_account,
-                    &record_account_authority,
+                    &[&record_account_authority],
                 )
                 .await
                 .unwrap();
@@ -891,7 +891,7 @@ async fn withdraw_withheld_tokens_from_accounts_with_option<S: Signers>(
                     &context_account_authority.pubkey(),
                     &equality_proof,
                     false,
-                    &context_account,
+                    &[&context_account],
                 )
                 .await
                 .unwrap();
@@ -917,7 +917,7 @@ async fn withdraw_withheld_tokens_from_accounts_with_option<S: Signers>(
                     &context_account.pubkey(),
                     destination_account,
                     &context_account_authority.pubkey(),
-                    &context_account_authority,
+                    &[&context_account_authority],
                 )
                 .await
                 .unwrap();


### PR DESCRIPTION
#### Problem
Some confidential transfer related functions in the token-client take in `Signer` instead of `Signers` as is done in other token-client functions.

#### Summary of Changes
I updated these functions to take in `Signers` to be in-line with the rest of the functions. The only exception is `confidential_transfer_create_record_account`. This function creates multiple transactions and they might require differing list of signers. Therefore, for this function, I ended up updating the parameters so that the different signers could be of differing type (previously, they had to be the same type, e.g. both signers have to be keypairs).