### PR TITLE
deps: Bump solana-curve25519 to 2.0.3 for consistency

### DIFF
--- a/token/confidential-transfer/ciphertext-arithmetic/Cargo.toml
+++ b/token/confidential-transfer/ciphertext-arithmetic/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 base64 = "0.22.1"
 bytemuck = "1.17.0"
-solana-curve25519 = "2.0.0"
+solana-curve25519 = "2.0.3"
 solana-zk-sdk = "2.0.3"
 
 [dev-dependencies]

--- a/token/confidential-transfer/proof-extraction/Cargo.toml
+++ b/token/confidential-transfer/proof-extraction/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 bytemuck = "1.17.0"
-solana-curve25519 = "2.0.0"
+solana-curve25519 = "2.0.3"
 solana-zk-sdk = "2.0.3"
 thiserror = "1.0.63"
 

--- a/update-solana-dependencies.sh
+++ b/update-solana-dependencies.sh
@@ -31,8 +31,10 @@ crates=(
   solana-cli-config
   solana-cli-output
   solana-client
+  solana-compute-budget
   solana-connection-cache
   solana-core
+  solana-curve25519
   solana-entry
   solana-faucet
   solana-frozen-abi
@@ -55,8 +57,10 @@ crates=(
   solana-compute-budget-program
   solana-config-program
   solana-stake-program
+  solana-system-program
   solana-vote-program
   solana-zk-token-proof-program
+  solana-zk-elgamal-proof-program
   solana-pubsub-client
   solana-quic-client
   solana-rayon-threadlimit


### PR DESCRIPTION
#### Problem

The solana-curve25519 dependency is marked at 2.0.0, where all of the other crates are at 2.0.3.

#### Summary of changes

Update the dependency to 2.0.3 for consistency. At the same time, add that crate along with a few others to `update-solana-dependencies.sh`