### PR TITLE
ci: Fix publish step by setting env vars

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -142,6 +142,11 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Set env vars
+        run: |
+          source ci/rust-version.sh
+          echo "RUST_STABLE=$rust_stable" >> $GITHUB_ENV
+
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_STABLE }}


### PR DESCRIPTION
#### Problem

The "Publish Rust Crate" job fails in the last step because the cargo toolchain hasn't been set properly.

#### Summary of changes

Set the environment variable before installing the rust toolchain.