### PR TITLE
CI: Add git-cliff step during publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -141,6 +141,8 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Set env vars
         run: |
@@ -201,8 +203,19 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         run: git push origin --follow-tags
 
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: ci/cliff.toml
+          args: "${{ steps.publish.outputs.old_git_tag }}"..master --include-path "${{ inputs.package_path }}/**" --github-repo "${{ github.repository }}"
+        env:
+          OUTPUT: TEMP_CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
       - name: Create GitHub release
         if: github.event.inputs.create_release == 'true' && github.event.inputs.dry_run != 'true'
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.publish.outputs.new_git_tag }}
+          bodyFile: TEMP_CHANGELOG.md
+          name: ${{ steps.publish.outputs.release_title }}

--- a/ci/cliff.toml
+++ b/ci/cliff.toml
@@ -1,0 +1,58 @@
+# git-cliff configuration file
+# https://git-cliff.org/docs/configuration
+#
+# Lines starting with "#" are comments.
+# Configuration options are organized into tables and keys.
+# See documentation for more information on available options.
+
+[changelog]
+header = """
+## What's new
+"""
+# template for the changelog body
+# https://tera.netlify.app/docs
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}\
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first | trim }}\
+        {% if commit.github.username %} by @{{ commit.github.username }}{%- endif %}\
+    {% endfor %}\
+{% endfor %}
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+footer = """
+"""
+postprocessors = [ ]
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = []
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^build\\(deps\\)", skip = true },
+    { message = "^build\\(deps-dev\\)", skip = true },
+    { message = "^ci", skip = true },
+    { body = ".*", group = "Changes" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = ""
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"
+# limit the number of commits included in the changelog.
+# limit_commits = 42

--- a/ci/publish-rust.sh
+++ b/ci/publish-rust.sh
@@ -20,6 +20,9 @@ DRY_RUN=$3
 # Go to the directory
 cd "${PACKAGE_PATH}"
 
+# Get the old version, used with git-cliff
+old_version=$(readCargoVariable version "Cargo.toml")
+
 # Publish the new version.
 if [[ -n ${DRY_RUN} ]]; then
   cargo release ${LEVEL}
@@ -36,11 +39,15 @@ fi
 new_version=$(readCargoVariable version "Cargo.toml")
 package_name=$(readCargoVariable name "Cargo.toml")
 tag_name="$(echo $package_name | sed 's/spl-//')"
-new_git_tag="${tag_name}@v${new_version}"
+new_git_tag="${tag_name}-v${new_version}"
+old_git_tag="${tag_name}-v${old_version}"
+release_title="SPL ${tag_name} - v${new_version}"
 
 # Expose the new version to CI if needed.
 if [[ -n $CI ]]; then
   echo "new_git_tag=${new_git_tag}" >> $GITHUB_OUTPUT
+  echo "old_git_tag=${old_git_tag}" >> $GITHUB_OUTPUT
+  echo "release_title=${release_title}" >> $GITHUB_OUTPUT
 fi
 
 # Soft reset the last commit so we can create our own commit and tag.


### PR DESCRIPTION
#### Problem

The publish step is great, but there's still some manual work to add the changelog and correct title for the created release.

#### Summary of changes

Use git-cliff to generate the release notes. This comes with a very simple cliff.toml which will do minimal processing, since we don't follow conventional commits in the repo.

Here's a test run for the given input, which filters out all dependabot bumps, which are typically less interesting.

```
$ git-cliff -c ci/cliff.toml "pod-v0.3.0"..master --include-path "libraries/pod/**" --github-repo "solana-labs/solana-program-library"
```

Output:

```
## What's new

- Publish pod v0.3.2 by @github-actions[bot]
- [token-2022] Upgrade to `zk-sdk` (#7148) by @samkim-crypto
- Implement `Default` for `PodOption` (#7083) by @joncinque
- Bump to 0.3.1 (#7075) by @febo
- Improve `PodOption` type (#7076) by @febo
- Add `PodU128` type (#7012) by @febo
- Add `PodOption` type (#6886) by @febo
- Use `bytemuck_derive` explicitly (#6928) by @joncinque
```

Note: we (I?) missed publishing pod-v0.3.1, which is why this picks up the previous bump too.