### PR TITLE
ci: Fix tag in publish-rust step

### DIFF
--- a/ci/publish-rust.sh
+++ b/ci/publish-rust.sh
@@ -36,7 +36,7 @@ fi
 new_version=$(readCargoVariable version "Cargo.toml")
 package_name=$(readCargoVariable name "Cargo.toml")
 tag_name="$(echo $package_name | sed 's/spl-//')"
-new_git_tag="${tag_name}@v${new_version}"
+new_git_tag="${tag_name}-v${new_version}"
 
 # Expose the new version to CI if needed.
 if [[ -n $CI ]]; then


### PR DESCRIPTION
#### Problem

The tag is incorrect in the publish step, using an `@` instead of a `-`, ie `token-2022@v1.0.0` instead of `token-2022-v1.0.0`.

#### Summary of changes

Change the `@` to a `-`