### PR TITLE
Bump token-metadata-js and token-group-js

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,11 +698,11 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@solana/spl-token-group':
-        specifier: ^0.0.5
+        specifier: ^0.0.6
         version: link:../../token-group/js
       '@solana/spl-token-metadata':
-        specifier: ^0.1.3
-        version: 0.1.4(@solana/web3.js@1.95.3)(fastestsmallesttextencoderdecoder@1.0.22)
+        specifier: ^0.1.5
+        version: link:../../token-metadata/js
       buffer:
         specifier: ^6.0.3
         version: 6.0.3

--- a/token-group/js/package.json
+++ b/token-group/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token-group",
     "description": "SPL Token Group Interface JS API",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-token-metadata",
     "description": "SPL Token Metadata Interface JS API",
-    "version": "0.1.3",
+    "version": "0.1.5",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -56,7 +56,7 @@
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
         "@solana/spl-token-group": "^0.0.5",
-        "@solana/spl-token-metadata": "^0.1.3",
+        "@solana/spl-token-metadata": "^0.1.5",
         "buffer": "^6.0.3"
     },
     "devDependencies": {

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -55,7 +55,7 @@
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/spl-token-group": "^0.0.5",
+        "@solana/spl-token-group": "^0.0.6",
         "@solana/spl-token-metadata": "^0.1.5",
         "buffer": "^6.0.3"
     },


### PR DESCRIPTION
#### Problem
As pointed out in #7202, `@solana/spl-token-metadata` depends on a newer version of `@solana/codecs`, which some developers would like to use. Additionally, `@solana/spl-token-group` also depends on this new codecs API, so it makes sense to bump them both together!

We can wait to publish a new patch for `@solana/spl-token` until that's been requested as well, if so desired.

#### Summary of Changes
Bump the patch versions of both `@solana/spl-token-metadata` and `@solana/spl-token-group`.

At one point some of the JS packages fell out of sync with their published versions, so token-metadata skips one here. We rectified a few of these with https://github.com/solana-labs/solana-program-library/pull/7000, but looks like metadata didn't get a release during that one.

Closes #7202