### PR TITLE
type-length-value: Revert specifying solana program crate path

### DIFF
--- a/libraries/type-length-value/src/error.rs
+++ b/libraries/type-length-value/src/error.rs
@@ -3,10 +3,7 @@
 use spl_program_error::*;
 
 /// Errors that may be returned by the Token program.
-#[spl_program_error(
-    hash_error_code_start = 1_202_666_432,
-    solana_program = "solana_program"
-)]
+#[spl_program_error(hash_error_code_start = 1_202_666_432)]
 pub enum TlvError {
     /// Type not found in TLV data
     #[error("Type not found in TLV data")]


### PR DESCRIPTION
#### Problem

While trying to publish type-length-value, there's an issue because its error definition requires new changes to spl_program_error.

#### Summary of changes

There are a lot of packages to publish for the new token-2022, so to keep things simple, revert the usage of the new macro.