### PR TITLE
CI: Install build deps before publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -153,6 +153,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_STABLE }}
 
+      - name: Install dependencies
+        run: ./ci/install-build-deps.sh
+
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
#### Problem

The publish step can fail because the protobuf compiler is missing: https://github.com/solana-labs/solana-program-library/actions/runs/10596818547/job/29366085606

#### Summary of changes

Install build deps during publish step