### PR TITLE
ci: Rebase during publish step

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -183,6 +183,9 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
+      - name: Rebase
+        run: git pull --rebase origin
+
       - name: Publish Crate
         id: publish
         env:


### PR DESCRIPTION
#### Problem

Sometimes, while the publish workflow is running, we merge a different PR, which means that the workflow is running against an older commit. This makes the step to push the tag commit fail sometimes, but this happens *after* the new crate has already been published. This means that we end up publishing crates that don't have any commits attached to them.

#### Summary of changes

Add a step to rebase before publishing.

cc @lorisleiva in case you want to do something similar for the template repos