### PR TITLE
Publish type-length-value v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7482,7 +7482,7 @@ dependencies = [
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7500,7 +7500,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
 ]
 
 [[package]]
@@ -7556,7 +7556,7 @@ dependencies = [
  "spl-token-group-interface 0.3.0",
  "spl-token-metadata-interface 0.4.0",
  "spl-transfer-hook-interface 0.7.0",
- "spl-type-length-value 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.5.0",
  "thiserror",
 ]
 
@@ -7591,7 +7591,7 @@ dependencies = [
  "spl-token-group-interface 0.4.1",
  "spl-token-metadata-interface 0.5.0",
  "spl-transfer-hook-interface 0.8.1",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
  "thiserror",
 ]
 
@@ -7704,7 +7704,7 @@ dependencies = [
  "spl-token-group-example",
  "spl-token-group-interface 0.4.1",
  "spl-token-metadata-interface 0.5.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
 ]
 
 [[package]]
@@ -7762,7 +7762,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-group-interface 0.4.1",
  "spl-token-metadata-interface 0.5.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
 ]
 
 [[package]]
@@ -7787,7 +7787,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
 ]
 
 [[package]]
@@ -7834,7 +7834,7 @@ dependencies = [
  "spl-token-2022 5.0.1",
  "spl-token-client",
  "spl-token-metadata-interface 0.5.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
  "test-case",
 ]
 
@@ -7849,7 +7849,7 @@ dependencies = [
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-type-length-value 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7863,7 +7863,7 @@ dependencies = [
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
 ]
 
 [[package]]
@@ -7987,7 +7987,7 @@ dependencies = [
  "spl-tlv-account-resolution 0.8.0",
  "spl-token-2022 5.0.1",
  "spl-transfer-hook-interface 0.8.1",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
 ]
 
 [[package]]
@@ -8003,7 +8003,7 @@ dependencies = [
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-tlv-account-resolution 0.7.0",
- "spl-type-length-value 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -8017,20 +8017,8 @@ dependencies = [
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
  "spl-tlv-account-resolution 0.8.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
  "tokio",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.5.0"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.4.0",
- "spl-program-error 0.5.0",
- "spl-type-length-value-derive",
 ]
 
 [[package]]
@@ -8044,6 +8032,18 @@ dependencies = [
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.6.0"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.4.0",
+ "spl-program-error 0.5.0",
+ "spl-type-length-value-derive",
 ]
 
 [[package]]
@@ -8062,7 +8062,7 @@ dependencies = [
  "borsh 1.5.1",
  "solana-program",
  "spl-discriminator 0.3.0",
- "spl-type-length-value 0.5.0",
+ "spl-type-length-value 0.6.0",
 ]
 
 [[package]]

--- a/libraries/tlv-account-resolution/Cargo.toml
+++ b/libraries/tlv-account-resolution/Cargo.toml
@@ -18,7 +18,7 @@ solana-program = "2.0.3"
 spl-discriminator = { version = "0.3.0", path = "../discriminator" }
 spl-program-error = { version = "0.5.0", path = "../program-error" }
 spl-pod = { version = "0.4.0", path = "../pod" }
-spl-type-length-value = { version = "0.5.0", path = "../type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../type-length-value" }
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/libraries/type-length-value-derive-test/Cargo.toml
+++ b/libraries/type-length-value-derive-test/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 borsh = "1.5.1"
 solana-program = "2.0.3"
 spl-discriminator = { version = "0.3.0", path = "../discriminator" }
-spl-type-length-value = { version = "0.5.0", path = "../type-length-value", features = [
+spl-type-length-value = { version = "0.6.0", path = "../type-length-value", features = [
   "derive",
 ] }

--- a/libraries/type-length-value/Cargo.toml
+++ b/libraries/type-length-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-type-length-value"
-version = "0.5.0"
+version = "0.6.0"
 description = "Solana Program Library Type-Length-Value Management"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/token-collection/program/Cargo.toml
+++ b/token-collection/program/Cargo.toml
@@ -19,7 +19,7 @@ spl-token-2022 = { version = "5.0.1", path = "../../token/program-2022", feature
 spl-token-group-example = { version = "0.2", path = "../../token-group/example", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.4.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.5.0", path = "../../token-metadata/interface" }
-spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "2.0.3"

--- a/token-group/example/Cargo.toml
+++ b/token-group/example/Cargo.toml
@@ -16,7 +16,7 @@ solana-program = "2.0.3"
 spl-pod = { version = "0.4.0", path = "../../libraries/pod" }
 spl-token-2022 = { version = "5.0.1", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.4.1", path = "../interface" }
-spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "2.0.3"

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -15,7 +15,7 @@ spl-pod = { version = "0.4.0", path = "../../libraries/pod", features = ["borsh"
 spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
 
 [dev-dependencies]
-spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value", features = ["derive"] }
+spl-type-length-value = { version = "0.6.0", path = "../../libraries/type-length-value", features = ["derive"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/token-metadata/example/Cargo.toml
+++ b/token-metadata/example/Cargo.toml
@@ -15,7 +15,7 @@ test-sbf = []
 solana-program = "2.0.3"
 spl-token-2022 = { version = "5.0.1", path = "../../token/program-2022", features = ["no-entrypoint"] }
 spl-token-metadata-interface = { version = "0.5.0", path = "../interface" }
-spl-type-length-value = { version = "0.5.0" , path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.4.0", path = "../../libraries/pod" }
 
 [dev-dependencies]

--- a/token-metadata/interface/Cargo.toml
+++ b/token-metadata/interface/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.209", optional = true }
 solana-program = "2.0.3"
 spl-discriminator = { version = "0.3.0", path = "../../libraries/discriminator" }
 spl-program-error = { version = "0.5.0", path = "../../libraries/program-error" }
-spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.4.0", path = "../../libraries/pod", features = [
   "borsh",
 ] }

--- a/token/program-2022/Cargo.toml
+++ b/token/program-2022/Cargo.toml
@@ -32,7 +32,7 @@ spl-token-confidential-transfer-proof-extraction = { version = "0.1.0", path = "
 spl-token-group-interface = { version = "0.4.1", path = "../../token-group/interface" }
 spl-token-metadata-interface = { version = "0.5.0", path = "../../token-metadata/interface" }
 spl-transfer-hook-interface = { version = "0.8.1", path = "../transfer-hook/interface" }
-spl-type-length-value = { version = "0.5.0", path = "../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../../libraries/type-length-value" }
 spl-pod = { version = "0.4.0", path = "../../libraries/pod" }
 thiserror = "1.0"
 serde = { version = "1.0.209", optional = true }

--- a/token/transfer-hook/example/Cargo.toml
+++ b/token/transfer-hook/example/Cargo.toml
@@ -19,7 +19,7 @@ solana-program = "2.0.3"
 spl-tlv-account-resolution = { version = "0.8.0", path = "../../../libraries/tlv-account-resolution" }
 spl-token-2022 = { version = "5.0.1",  path = "../../program-2022", features = ["no-entrypoint"] }
 spl-transfer-hook-interface = { version = "0.8.1", path = "../interface" }
-spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../../../libraries/type-length-value" }
 
 [dev-dependencies]
 solana-program-test = "2.0.3"

--- a/token/transfer-hook/interface/Cargo.toml
+++ b/token/transfer-hook/interface/Cargo.toml
@@ -14,7 +14,7 @@ solana-program = "2.0.3"
 spl-discriminator = { version = "0.3.0" , path = "../../../libraries/discriminator" }
 spl-program-error = { version = "0.5.0" , path = "../../../libraries/program-error" }
 spl-tlv-account-resolution = { version = "0.8.0", path = "../../../libraries/tlv-account-resolution" }
-spl-type-length-value = { version = "0.5.0" , path = "../../../libraries/type-length-value" }
+spl-type-length-value = { version = "0.6.0", path = "../../../libraries/type-length-value" }
 spl-pod = { version = "0.4.0", path = "../../../libraries/pod" }
 
 [lib]


### PR DESCRIPTION
#### Problem

There was an issue in the publish for TLV 0.6.0, which means that the crate was published, but the version bump didn't go through: https://github.com/solana-labs/solana-program-library/actions/runs/10595201490/job/29360836916

#### Summary of changes

Do the version bump.