### PR TITLE
ci: Add git tag / commit message with cargo release

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -205,10 +205,6 @@ jobs:
 
           ./ci/publish-rust.sh "${{ inputs.package_path }}" $LEVEL $OPTIONS
 
-      - name: Push Commit and Tag
-        if: github.event.inputs.dry_run != 'true'
-        run: git push origin --follow-tags
-
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'
         uses: orhun/git-cliff-action@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,8 @@ exclude = [
 ]
 
 resolver = "2"
+
+[workspace.metadata.release]
+pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
+tag-message = "Publish {{crate_name}} v{{version}}"
+consolidate-commits = false


### PR DESCRIPTION
#### Problem

The publish workflow is great, but it does some work by hand, namely creating the git commit and tag. `cargo release` can do this, but we currently don't use it because we aren't customizing it.

#### Summary of changes

Add configuration options to the top-level Cargo.toml and let cargo release do everything for us.

Side note: this *does not* resolve the issue of publishing a crate and then failing to push the git commit. `cargo release` is just doing the steps in series, so if `git push` fails after `cargo publish`, you're in the same situation as now. This just makes the scripts and workflow a bit simpler