### PR TITLE
ci: Update to upload / download artifact v4

### DIFF
--- a/.github/workflows/pull-request-account-compression.yml
+++ b/.github/workflows/pull-request-account-compression.yml
@@ -70,7 +70,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh account-compression
 
       - name: Upload programs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: account-compression-programs
           path: "account-compression/target/deploy/*.so"

--- a/.github/workflows/pull-request-name-service.yml
+++ b/.github/workflows/pull-request-name-service.yml
@@ -61,13 +61,6 @@ jobs:
       - name: Build and test
         run: ./ci/cargo-test-sbf.sh name-service
 
-      - name: Upload programs
-        uses: actions/upload-artifact@v3
-        with:
-          name: name-service-programs
-          path: "target/deploy/*.so"
-          if-no-files-found: error
-
   js-test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-request-single-pool.yml
+++ b/.github/workflows/pull-request-single-pool.yml
@@ -69,13 +69,6 @@ jobs:
       - name: Build and test
         run: ./ci/cargo-test-sbf.sh single-pool/program
 
-      - name: Upload programs
-        uses: actions/upload-artifact@v3
-        with:
-          name: single-pool-programs
-          path: "target/deploy/*.so"
-          if-no-files-found: error
-
   cargo-build-test-cli:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request-stake-pool.yml
+++ b/.github/workflows/pull-request-stake-pool.yml
@@ -79,7 +79,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh stake-pool
 
       - name: Upload programs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: stake-pool-programs
           path: "target/deploy/*.so"
@@ -121,7 +121,7 @@ jobs:
           key: pip-stake-pool-${{ hashFiles('stake-pool/py/requirements.txt') }}
 
       - name: Download programs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: stake-pool-programs
           path: target/deploy

--- a/.github/workflows/pull-request-token-lending.yml
+++ b/.github/workflows/pull-request-token-lending.yml
@@ -65,13 +65,6 @@ jobs:
       - name: Build and test
         run: ./ci/cargo-test-sbf.sh token-lending
 
-      - name: Upload programs
-        uses: actions/upload-artifact@v3
-        with:
-          name: token-lending-programs
-          path: "target/deploy/*.so"
-          if-no-files-found: error
-
   js-test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-request-token-swap.yml
+++ b/.github/workflows/pull-request-token-swap.yml
@@ -80,13 +80,6 @@ jobs:
         run: |
           mv target/deploy-production/spl_token_swap.so target/deploy/spl_token_swap_production.so
 
-      - name: Upload programs
-        uses: actions/upload-artifact@v3
-        with:
-          name: token-swap-programs
-          path: "target/deploy/*.so"
-          if-no-files-found: error
-
   js-test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pull-request-token.yml
+++ b/.github/workflows/pull-request-token.yml
@@ -68,13 +68,6 @@ jobs:
       - name: Build and test token
         run: ./ci/cargo-test-sbf.sh token
 
-      - name: Upload programs
-        uses: actions/upload-artifact@v3
-        with:
-          name: token-programs
-          path: "target/deploy/*.so"
-          if-no-files-found: error
-
   cargo-test-token-2022-serde:
     runs-on: ubuntu-latest
     steps:
@@ -153,7 +146,7 @@ jobs:
         run: ./ci/cargo-test-sbf.sh token/transfer-hook/example
 
       - name: Upload program
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spl-transfer-hook-example
           path: "target/deploy/*.so"
@@ -201,13 +194,6 @@ jobs:
 
       - name: Build and test ATA
         run: ./ci/cargo-test-sbf.sh associated-token-account
-
-      - name: Upload program
-        uses: actions/upload-artifact@v3
-        with:
-          name: associated-token-account-program
-          path: "target/deploy/*.so"
-          if-no-files-found: error
 
   cargo-test-sbf-token-2022:
     runs-on: ubuntu-latest
@@ -342,7 +328,7 @@ jobs:
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
       - name: Download spl-transfer-hook-example program
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spl-transfer-hook-example
           path: target/deploy


### PR DESCRIPTION
#### Problem

CI is still on the older v3 of upload-artifact / download-artifact.

#### Summary of changes

We were needlessly uploading programs before, so remove those instances, and otherwise, use v4 everywhere.