### PR TITLE
token-2022: Update security.txt info

### DIFF
--- a/token/program-2022/src/entrypoint.rs
+++ b/token/program-2022/src/entrypoint.rs
@@ -33,7 +33,7 @@ security_txt! {
     // Optional Fields
     preferred_languages: "en",
     source_code: "https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022",
-    source_revision: "61a2fb715e51f14b12ccde56dea30650a6bca487",
-    source_release: "token-2022-v4.0.1",
+    source_revision: "070934ae4f2975d602caa6bd1e88b2c010e4cab5",
+    source_release: "token-2022-v5.0.2",
     auditors: "https://github.com/solana-labs/security-audits#token-2022"
 }


### PR DESCRIPTION
#### Problem

The new token-2022 is out, but the security.txt is outdated.

#### Summary of changes

Update the revision and tag for the deployed version