### PR TITLE
resolved-conflict in spl-noop and spl-account-compression

### DIFF
--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -18,7 +18,7 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.29.0"
+anchor-lang = "0.30.1"
 bytemuck = "1.13"
 solana-program = ">=1.18.11,<=2"
 spl-concurrent-merkle-tree = { version = "0.3.0", path = "../../../libraries/concurrent-merkle-tree" }

--- a/account-compression/programs/account-compression/src/noop/mod.rs
+++ b/account-compression/programs/account-compression/src/noop/mod.rs
@@ -8,14 +8,14 @@
 //! deserializing the CPI instruction data.
 
 use crate::events::{AccountCompressionEvent, ApplicationDataEvent, ApplicationDataEventV1};
+use anchor_lang::solana_program::instruction::Instruction;
 use anchor_lang::{prelude::*, solana_program::program::invoke};
-
 #[derive(Clone)]
 pub struct Noop;
 
 impl anchor_lang::Id for Noop {
     fn id() -> Pubkey {
-        spl_noop::id()
+        crate::id()
     }
 }
 
@@ -24,7 +24,11 @@ pub fn wrap_event<'info>(
     noop_program: &Program<'info, Noop>,
 ) -> Result<()> {
     invoke(
-        &spl_noop::instruction(event.try_to_vec()?),
+        &Instruction {
+            program_id: crate::id(),
+            accounts: vec![],
+            data: event.try_to_vec()?,
+        },
         &[noop_program.to_account_info()],
     )?;
     Ok(())

--- a/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
+++ b/account-compression/programs/account-compression/src/state/concurrent_merkle_tree_header.rs
@@ -8,7 +8,7 @@ use crate::error::AccountCompressionError;
 
 pub const CONCURRENT_MERKLE_TREE_HEADER_SIZE_V1: usize = 2 + 54;
 
-#[derive(Debug, Copy, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, Copy, Clone, PartialEq, AnchorDeserialize, AnchorSerialize)]
 #[repr(u8)]
 pub enum CompressionAccountType {
     /// Uninitialized
@@ -166,10 +166,10 @@ pub fn merkle_tree_get_size(header: &ConcurrentMerkleTreeHeader) -> Result<usize
         (7, 16) => Ok(size_of::<ConcurrentMerkleTree<7, 16>>()),
         (8, 16) => Ok(size_of::<ConcurrentMerkleTree<8, 16>>()),
         (9, 16) => Ok(size_of::<ConcurrentMerkleTree<9, 16>>()),
-        (10, 32)=> Ok(size_of::<ConcurrentMerkleTree<10, 32>>()),
-        (11, 32)=> Ok(size_of::<ConcurrentMerkleTree<11, 32>>()),
-        (12, 32)=> Ok(size_of::<ConcurrentMerkleTree<12, 32>>()),
-        (13, 32)=> Ok(size_of::<ConcurrentMerkleTree<13, 32>>()),
+        (10, 32) => Ok(size_of::<ConcurrentMerkleTree<10, 32>>()),
+        (11, 32) => Ok(size_of::<ConcurrentMerkleTree<11, 32>>()),
+        (12, 32) => Ok(size_of::<ConcurrentMerkleTree<12, 32>>()),
+        (13, 32) => Ok(size_of::<ConcurrentMerkleTree<13, 32>>()),
         (14, 64) => Ok(size_of::<ConcurrentMerkleTree<14, 64>>()),
         (14, 256) => Ok(size_of::<ConcurrentMerkleTree<14, 256>>()),
         (14, 1024) => Ok(size_of::<ConcurrentMerkleTree<14, 1024>>()),


### PR DESCRIPTION
there was a confusion b/w anchor and solana PubKey in spl-noop and spl-account-compression which was probably arising from **solana-program** version conflict b/w **spl-noop** and **anchor-lang 0.30.1** in **spl-account-compression** 
![Screenshot from 2024-09-07 15-43-30](https://github.com/user-attachments/assets/00049080-f173-403d-890b-ad371293e758)

As a Solution ,directly implementing spl-noop functionalities  in spl-account-compression resolved the conflict 







fix #7247 
fix #7248 