### PR TITLE
ci: Add tonic to audit ignore

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -14,5 +14,14 @@ cargo_audit_ignores=(
   #
   # Remove once SPL upgrades to curve25519-dalek v4
   --ignore RUSTSEC-2024-0344
+
+  # Crate:     tonic
+  # Version:   0.9.2
+  # Title:     Remotely exploitable Denial of Service in Tonic
+  # Date:      2024-10-01
+  # ID:        RUSTSEC-2024-0376
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
+  # Solution:  Upgrade to >=0.12.3
+  --ignore RUSTSEC-2024-0376
 )
 cargo +"$rust_stable" audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

Similar to https://github.com/anza-xyz/agave/pull/3052, we need to ignore the RUSTSEC advisory on tonic until it's resolved upstream.

#### Summary of changes

Ignore the tonic advisory.