### PR TITLE
[@solana/spl-stake-pool] export the StakePoolLayout

### DIFF
--- a/stake-pool/js/src/index.ts
+++ b/stake-pool/js/src/index.ts
@@ -46,7 +46,7 @@ import BN from 'bn.js';
 export type { StakePool, AccountType, ValidatorList, ValidatorStakeInfo } from './layouts';
 export { STAKE_POOL_PROGRAM_ID } from './constants';
 export * from './instructions';
-export { StakePoolLayout } from './layouts';
+export { StakePoolLayout, ValidatorListLayout, ValidatorStakeInfoLayout } from './layouts';
 
 export interface ValidatorListAccount {
   pubkey: PublicKey;

--- a/stake-pool/js/src/index.ts
+++ b/stake-pool/js/src/index.ts
@@ -46,6 +46,7 @@ import BN from 'bn.js';
 export type { StakePool, AccountType, ValidatorList, ValidatorStakeInfo } from './layouts';
 export { STAKE_POOL_PROGRAM_ID } from './constants';
 export * from './instructions';
+export { StakePoolLayout } from './layouts';
 
 export interface ValidatorListAccount {
   pubkey: PublicKey;


### PR DESCRIPTION
Necessary to load individual StakePools by their pubkey (possibly across different stake pool program deployments) and decode.