### PR TITLE
stake-pool-js: Bump to 1.1.7

### DIFF
--- a/stake-pool/js/package.json
+++ b/stake-pool/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/spl-stake-pool",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "SPL Stake Pool Program JS API",
   "scripts": {
     "build": "tsc && cross-env NODE_ENV=production rollup -c",


### PR DESCRIPTION
#### Problem

The 1.1.6 publish didn't work for some reason.

#### Summary of changes

Bump to 1.1.7 and do it again