### PR TITLE
CI: Use `commit.remote` in git-cliff

### DIFF
--- a/ci/cliff.toml
+++ b/ci/cliff.toml
@@ -15,7 +15,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}\
     {% for commit in commits %}
         - {{ commit.message | upper_first | split(pat="\n") | first | trim }}\
-        {% if commit.github.username %} by @{{ commit.github.username }}{%- endif %}\
+        {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
     {% endfor %}\
 {% endfor %}
 """


### PR DESCRIPTION
#### Problem

git-cliff has deprecated the `commit.github` field available during parsing, opting for `commit.remote` instead.

#### Summary of changes

Use `commit.remote` instead of `commit.github`.