### PR TITLE
Revert "Set patch version to only use solana-program <2"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "borsh 1.5.1",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-token 6.0.0",
  "thiserror",
  "uint",
@@ -783,16 +783,6 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
-dependencies = [
- "borsh-derive 0.9.3",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
@@ -813,25 +803,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
-dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "borsh-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
 dependencies = [
- "borsh-derive-internal 0.10.3",
- "borsh-schema-derive-internal 0.10.3",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.107",
@@ -853,31 +830,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "borsh-derive-internal"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -915,12 +870,6 @@ dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
-
-[[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
@@ -1978,7 +1927,7 @@ name = "flash_loan_receiver"
 version = "1.0.0"
 dependencies = [
  "arrayref",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-token 6.0.0",
 ]
 
@@ -2277,15 +2226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
 ]
 
 [[package]]
@@ -5075,7 +5015,7 @@ dependencies = [
  "Inflector",
  "base64 0.22.1",
  "bincode",
- "bs58 0.5.1",
+ "bs58",
  "bv",
  "lazy_static",
  "serde",
@@ -5148,7 +5088,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rustc_version",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",
@@ -5163,7 +5103,7 @@ dependencies = [
  "borsh 1.5.1",
  "futures 0.3.31",
  "solana-banks-interface",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-sdk",
  "tarpc",
  "thiserror",
@@ -5436,7 +5376,7 @@ dependencies = [
  "ahash 0.8.11",
  "base64 0.22.1",
  "bincode",
- "bs58 0.5.1",
+ "bs58",
  "bytes",
  "chrono",
  "crossbeam-channel",
@@ -5537,7 +5477,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek",
- "solana-program 2.0.3",
+ "solana-program",
  "thiserror",
 ]
 
@@ -5588,50 +5528,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-frozen-abi"
-version = "1.18.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ab2c30c15311b511c0d1151e4ab6bc9a3e080a37e7c6e7c2d96f5784cf9434"
-dependencies = [
- "block-buffer 0.10.4",
- "bs58 0.4.0",
- "bv",
- "either",
- "generic-array 0.14.7",
- "im",
- "lazy_static",
- "log",
- "memmap2 0.5.10",
- "rustc_version",
- "serde",
- "serde_bytes",
- "serde_derive",
- "sha2 0.10.8",
- "solana-frozen-abi-macro",
- "subtle",
- "thiserror",
-]
-
-[[package]]
-name = "solana-frozen-abi-macro"
-version = "1.18.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142f779c3633ac83c84d04ff06c70e1f558c876f13358bed77ba629c7417932"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "solana-geyser-plugin-manager"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef9c649ca5e09047bc250b6df1e1e87f9ca42489e3d9b0c9fbbec80a05382fa"
 dependencies = [
  "agave-geyser-plugin-interface",
- "bs58 0.5.1",
+ "bs58",
  "crossbeam-channel",
  "json5",
  "jsonrpc-core",
@@ -5822,7 +5725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ed80bcbc059b0c7e3b1494881224fca5b32d0df3cdbc2d60c5a63855b9f3653"
 dependencies = [
  "fast-math",
- "solana-program 2.0.3",
+ "solana-program",
 ]
 
 [[package]]
@@ -5927,61 +5830,6 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.18.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10f4588cefd716b24a1a40dd32c278e43a560ab8ce4de6b5805c9d113afdfa1"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "base64 0.21.7",
- "bincode",
- "bitflags 2.5.0",
- "blake3",
- "borsh 0.10.3",
- "borsh 0.9.3",
- "borsh 1.5.1",
- "bs58 0.4.0",
- "bv",
- "bytemuck",
- "cc",
- "console_error_panic_hook",
- "console_log",
- "curve25519-dalek",
- "getrandom 0.2.10",
- "itertools 0.10.5",
- "js-sys",
- "lazy_static",
- "libc",
- "libsecp256k1",
- "light-poseidon",
- "log",
- "memoffset 0.9.0",
- "num-bigint 0.4.5",
- "num-derive",
- "num-traits",
- "parking_lot 0.12.0",
- "rand 0.8.5",
- "rustc_version",
- "rustversion",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-sdk-macro 1.18.26",
- "thiserror",
- "tiny-bip39",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
-name = "solana-program"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70306519f79aa7699264d76d7f4fe252ab22fef3a85404a748a42f8dd750653e"
@@ -5996,7 +5844,7 @@ dependencies = [
  "blake3",
  "borsh 0.10.3",
  "borsh 1.5.1",
- "bs58 0.5.1",
+ "bs58",
  "bv",
  "bytemuck",
  "bytemuck_derive",
@@ -6021,7 +5869,7 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.8",
  "sha3 0.10.8",
- "solana-sdk-macro 2.0.3",
+ "solana-sdk-macro",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -6176,7 +6024,7 @@ checksum = "c017bb0895569b24f0cade001a61aaa00870e0afb5193f16cd20adfab5bc6f16"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "bs58 0.5.1",
+ "bs58",
  "crossbeam-channel",
  "dashmap",
  "itertools 0.12.1",
@@ -6236,7 +6084,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
- "bs58 0.5.1",
+ "bs58",
  "indicatif",
  "log",
  "reqwest",
@@ -6262,7 +6110,7 @@ checksum = "e112f318737465bbc72a37a67bea1af546cb48a0fa036f580b0b9d811c37c44b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bs58 0.5.1",
+ "bs58",
  "jsonrpc-core",
  "reqwest",
  "reqwest-middleware",
@@ -6380,7 +6228,7 @@ dependencies = [
  "bincode",
  "bitflags 2.5.0",
  "borsh 1.5.1",
- "bs58 0.5.1",
+ "bs58",
  "bytemuck",
  "bytemuck_derive",
  "byteorder",
@@ -6413,24 +6261,11 @@ dependencies = [
  "sha2 0.10.8",
  "sha3 0.10.8",
  "siphasher",
- "solana-program 2.0.3",
- "solana-sdk-macro 2.0.3",
+ "solana-program",
+ "solana-sdk-macro",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sdk-macro"
-version = "1.18.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b75d0f193a27719257af19144fdaebec0415d1c9e9226ae4bd29b791be5e9bd"
-dependencies = [
- "bs58 0.4.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -6439,7 +6274,7 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bfdd94b479f125a64f028c31ca6b018cf7ab1a5ebc974f175c54dd56ad58b1"
 dependencies = [
- "bs58 0.5.1",
+ "bs58",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6526,7 +6361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561fb46c3630989f21a192fe5fc4a5f0c37bb10b5f5de62e5b3b8a00f635b564"
 dependencies = [
  "bincode",
- "bs58 0.5.1",
+ "bs58",
  "prost",
  "protobuf-src",
  "serde",
@@ -6708,7 +6543,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "borsh 1.5.1",
- "bs58 0.5.1",
+ "bs58",
  "lazy_static",
  "log",
  "serde",
@@ -6861,7 +6696,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-metrics",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",
@@ -6885,7 +6720,7 @@ dependencies = [
  "solana-gossip",
  "solana-ledger",
  "solana-logger",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-runtime",
  "solana-runtime",
  "solana-sdk",
@@ -6928,7 +6763,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-sdk",
  "subtle",
  "thiserror",
@@ -6973,7 +6808,7 @@ dependencies = [
  "serde_json",
  "sha3 0.9.1",
  "solana-curve25519",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-sdk",
  "subtle",
  "thiserror",
@@ -7021,7 +6856,7 @@ dependencies = [
  "borsh 1.5.1",
  "num-derive",
  "num-traits",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-token 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-2022 4.0.0",
  "thiserror",
@@ -7034,7 +6869,7 @@ dependencies = [
  "borsh 1.5.1",
  "num-derive",
  "num-traits",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-associated-token-account-client",
  "spl-token 6.0.0",
  "spl-token-2022 5.0.2",
@@ -7045,14 +6880,14 @@ dependencies = [
 name = "spl-associated-token-account-client"
 version = "1.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
 ]
 
 [[package]]
 name = "spl-associated-token-account-test"
 version = "0.0.1"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 5.0.1",
@@ -7068,7 +6903,7 @@ dependencies = [
  "borsh 1.5.1",
  "num-derive",
  "num-traits",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
@@ -7078,12 +6913,12 @@ dependencies = [
 
 [[package]]
 name = "spl-concurrent-merkle-tree"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "rand 0.8.5",
  "rand_distr",
- "solana-program 1.18.26",
+ "solana-program",
  "spl-merkle-tree-reference",
  "thiserror",
  "tokio",
@@ -7095,7 +6930,7 @@ version = "0.3.0"
 dependencies = [
  "borsh 1.5.1",
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator-derive 0.2.0",
 ]
 
@@ -7106,7 +6941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38ea8b6dedb7065887f12d62ed62c1743aa70749e8558f963609793f6fb12bc"
 dependencies = [
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -7158,7 +6993,7 @@ dependencies = [
 name = "spl-example-cross-program-invocation"
 version = "1.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7167,7 +7002,7 @@ dependencies = [
 name = "spl-example-custom-heap"
 version = "1.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7176,7 +7011,7 @@ dependencies = [
 name = "spl-example-logging"
 version = "1.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7185,7 +7020,7 @@ dependencies = [
 name = "spl-example-sysvar"
 version = "1.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7194,7 +7029,7 @@ dependencies = [
 name = "spl-example-transfer-lamports"
 version = "1.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7203,7 +7038,7 @@ dependencies = [
 name = "spl-example-transfer-tokens"
 version = "1.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
@@ -7214,7 +7049,7 @@ name = "spl-feature-proposal"
 version = "1.0.0"
 dependencies = [
  "borsh 1.5.1",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
@@ -7248,7 +7083,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_derive",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-governance-addin-api",
@@ -7264,7 +7099,7 @@ name = "spl-governance-addin-api"
 version = "0.1.4"
 dependencies = [
  "borsh 1.5.1",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-governance-tools",
 ]
 
@@ -7281,7 +7116,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_derive",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-governance-addin-api",
@@ -7304,7 +7139,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_derive",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-governance",
@@ -7328,7 +7163,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
@@ -7346,7 +7181,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-token 6.0.0",
  "thiserror",
 ]
@@ -7356,7 +7191,7 @@ name = "spl-instruction-padding"
 version = "0.2.0"
 dependencies = [
  "num_enum",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7367,7 +7202,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.5.1",
  "shank",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 5.0.1",
@@ -7385,7 +7220,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "proptest",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "thiserror",
@@ -7396,7 +7231,7 @@ dependencies = [
 name = "spl-memo"
 version = "5.0.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7407,14 +7242,14 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0dba2f2bb6419523405d21c301a32c9f9568354d4742552e7972af801f4bdb3"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
 ]
 
 [[package]]
 name = "spl-merkle-tree-reference"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
- "solana-program 1.18.26",
+ "solana-program",
  "thiserror",
 ]
 
@@ -7425,7 +7260,7 @@ dependencies = [
  "borsh 1.5.1",
  "num-derive",
  "num-traits",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "thiserror",
@@ -7440,7 +7275,7 @@ dependencies = [
  "borsh 1.5.1",
  "bytemuck",
  "bytemuck_derive",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-zk-token-sdk",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -7455,7 +7290,7 @@ dependencies = [
  "bytemuck_derive",
  "serde",
  "serde_json",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-zk-sdk",
  "spl-program-error 0.5.0",
 ]
@@ -7468,7 +7303,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serial_test",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-sdk",
  "spl-program-error-derive 0.4.1",
  "thiserror",
@@ -7482,7 +7317,7 @@ checksum = "d7b28bed65356558133751cc32b48a7a5ddfc59ac4e941314630bbed1ac10532"
 dependencies = [
  "num-derive",
  "num-traits",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-program-error-derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
@@ -7516,7 +7351,7 @@ dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.4.0",
@@ -7528,7 +7363,7 @@ name = "spl-shared-memory"
 version = "2.0.6"
 dependencies = [
  "arrayref",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
 ]
@@ -7545,7 +7380,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "rand 0.8.5",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "solana-security-txt",
@@ -7604,7 +7439,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_derive",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "solana-security-txt",
@@ -7623,7 +7458,7 @@ version = "2.0.0"
 dependencies = [
  "bincode",
  "borsh 1.5.1",
- "bs58 0.5.1",
+ "bs58",
  "clap 2.34.0",
  "serde",
  "serde_derive",
@@ -7634,7 +7469,7 @@ dependencies = [
  "solana-cli-output",
  "solana-client",
  "solana-logger",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-remote-wallet",
  "solana-sdk",
  "spl-associated-token-account 5.0.1",
@@ -7650,7 +7485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a75a5f0fcc58126693ed78a17042e9dc53f07e357d6be91789f7d62aff61a4"
 dependencies = [
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7666,7 +7501,7 @@ dependencies = [
  "futures-util",
  "serde",
  "solana-client",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.3.0",
@@ -7687,7 +7522,7 @@ dependencies = [
  "num_enum",
  "proptest",
  "serial_test",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "thiserror",
@@ -7704,7 +7539,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 2.0.3",
+ "solana-program",
  "thiserror",
 ]
 
@@ -7719,7 +7554,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7748,7 +7583,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.11.0",
  "serial_test",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "solana-security-txt",
@@ -7775,7 +7610,7 @@ dependencies = [
  "borsh 1.5.1",
  "bytemuck",
  "futures-util",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account 5.0.1",
@@ -7865,7 +7700,7 @@ dependencies = [
 name = "spl-token-collection"
 version = "0.1.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.3.0",
@@ -7925,7 +7760,7 @@ dependencies = [
 name = "spl-token-group-example"
 version = "0.2.1"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-discriminator 0.3.0",
@@ -7944,7 +7779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8752b85a5ecc1d9f3a43bce3dd9a6a053673aacf5deb513d1cbb88d3534ffd"
 dependencies = [
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7955,7 +7790,7 @@ name = "spl-token-group-interface"
 version = "0.4.2"
 dependencies = [
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
@@ -7972,7 +7807,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "proptest",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
@@ -7989,7 +7824,7 @@ dependencies = [
  "solana-cli-config",
  "solana-client",
  "solana-logger",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-sdk",
  "spl-token 6.0.0",
  "spl-token-lending",
@@ -7999,7 +7834,7 @@ dependencies = [
 name = "spl-token-metadata-example"
 version = "0.3.0"
 dependencies = [
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-pod 0.4.0",
@@ -8017,7 +7852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
 dependencies = [
  "borsh 1.5.1",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8031,7 +7866,7 @@ dependencies = [
  "borsh 1.5.1",
  "serde",
  "serde_json",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
@@ -8049,7 +7884,7 @@ dependencies = [
  "num-traits",
  "proptest",
  "roots",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-sdk",
  "spl-math",
  "spl-token 6.0.0",
@@ -8064,7 +7899,7 @@ version = "0.0.1"
 dependencies = [
  "arbitrary",
  "honggfuzz",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-math",
  "spl-token 6.0.0",
  "spl-token-swap",
@@ -8077,7 +7912,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-token 6.0.0",
@@ -8115,7 +7950,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "num_enum",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-associated-token-account 5.0.1",
  "spl-token 6.0.0",
  "spl-token-2022 5.0.2",
@@ -8153,7 +7988,7 @@ name = "spl-transfer-hook-example"
 version = "0.6.0"
 dependencies = [
  "arrayref",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-tlv-account-resolution 0.8.1",
@@ -8170,7 +8005,7 @@ checksum = "a110f33d941275d9f868b96daaa993f1e73b6806cc8836e43075b4d3ad8338a7"
 dependencies = [
  "arrayref",
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8184,7 +8019,7 @@ version = "0.8.2"
 dependencies = [
  "arrayref",
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
@@ -8200,7 +8035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdcd73ec187bc409464c60759232e309f83b52a18a9c5610bf281c9c6432918c"
 dependencies = [
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-pod 0.3.0",
  "spl-program-error 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8211,7 +8046,7 @@ name = "spl-type-length-value"
 version = "0.6.0"
 dependencies = [
  "bytemuck",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
@@ -8232,7 +8067,7 @@ name = "spl-type-length-value-derive-test"
 version = "0.1.0"
 dependencies = [
  "borsh 1.5.1",
- "solana-program 2.0.3",
+ "solana-program",
  "spl-discriminator 0.3.0",
  "spl-type-length-value 0.6.0",
 ]
@@ -8242,7 +8077,7 @@ name = "stateless-asks"
 version = "0.1.0"
 dependencies = [
  "borsh 1.5.1",
- "solana-program 2.0.3",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account-client",

--- a/libraries/concurrent-merkle-tree/Cargo.toml
+++ b/libraries/concurrent-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-concurrent-merkle-tree"
-version = "0.4.1"
+version = "0.4.0"
 description = "Solana Program Library Concurrent Merkle Tree"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -12,7 +12,7 @@ log = []
 sol-log = ["log"]
 
 [dependencies]
-solana-program = ">=1.18.11,<2"
+solana-program = ">=1.18.11,<=2"
 bytemuck = "1.19"
 thiserror = "1.0.64"
 

--- a/libraries/merkle-tree-reference/Cargo.toml
+++ b/libraries/merkle-tree-reference/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-merkle-tree-reference"
-version = "0.1.1"
+version = "0.1.0"
 description = "Reference implementation of a merkle tree"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-solana-program = ">=1.18.11,<2"
+solana-program = ">=1.18.11,<=2"
 thiserror = "1.0.64"
 
 [lib]


### PR DESCRIPTION
Reverts solana-labs/solana-program-library#7356 so that CI still passes for https://github.com/anza-xyz/agave/actions/runs/11372664282/job/31637497171