### PR TITLE
Use the SHA-256 implementation built into JavaScript engines

### DIFF
--- a/.github/workflows/pull-request-js.yml
+++ b/.github/workflows/pull-request-js.yml
@@ -44,7 +44,6 @@ jobs:
         package:
           [
             account-compression,
-            libraries,
             memo,
             name-service,
             stake-pool,
@@ -54,7 +53,9 @@ jobs:
             token-swap,
           ]
         include:
-          # Restrict single-pool and token-lending to supported Node.js versions.
+          # Restrict certain packages to supported Node.js versions.
+          - package: libraries
+            node-version: 20.x
           - package: single-pool
             node-version: 20.5
           - package: token-lending

--- a/libraries/type-length-value/js/README.md
+++ b/libraries/type-length-value/js/README.md
@@ -8,7 +8,7 @@ Library with utilities for working with Type-Length-Value structures in js.
 import { TlvState, SplDiscriminator } from '@solana/spl-type-length-value';
 
 const tlv = new TlvState(tlvData, discriminatorSize, lengthSize);
-const discriminator = splDiscriminate("<discriminator-hash-input>", discriminatorSize);
+const discriminator = await splDiscriminate("<discriminator-hash-input>", discriminatorSize);
 
 const firstValue = tlv.firstBytes(discriminator);
 

--- a/libraries/type-length-value/js/package.json
+++ b/libraries/type-length-value/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana/spl-type-length-value",
     "description": "SPL Type Length Value Library",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "repository": "https://github.com/solana-labs/solana-program-library",
     "license": "Apache-2.0",
@@ -43,6 +43,7 @@
         "watch": "tsc --build --verbose --watch tsconfig.all.json"
     },
     "dependencies": {
+        "@solana/assertions": "^2.0.0-rc.1",
         "buffer": "^6.0.3"
     },
     "devDependencies": {

--- a/libraries/type-length-value/js/package.json
+++ b/libraries/type-length-value/js/package.json
@@ -8,7 +8,7 @@
     "type": "module",
     "sideEffects": false,
     "engines": {
-        "node": ">=16"
+        "node": ">=19"
     },
     "files": [
         "lib",

--- a/libraries/type-length-value/js/src/splDiscriminate.ts
+++ b/libraries/type-length-value/js/src/splDiscriminate.ts
@@ -1,6 +1,8 @@
-import { createHash } from 'crypto';
+import { assertDigestCapabilityIsAvailable } from '@solana/assertions';
 
-export const splDiscriminate = (discriminator: string, length = 8): Buffer => {
-    const digest = createHash('sha256').update(discriminator).digest();
-    return digest.subarray(0, length);
-};
+export async function splDiscriminate(discriminator: string, length = 8): Promise<Uint8Array> {
+    assertDigestCapabilityIsAvailable();
+    const bytes = new TextEncoder().encode(discriminator);
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return new Uint8Array(digest).subarray(0, length);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
 
   libraries/type-length-value/js:
     dependencies:
+      '@solana/assertions':
+        specifier: ^2.0.0-rc.1
+        version: 2.0.0-rc.1(typescript@5.6.3)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,7 +464,7 @@ importers:
         version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/spl-type-length-value':
         specifier: 0.1.0
-        version: link:../../libraries/type-length-value/js
+        version: 0.1.0
     devDependencies:
       '@solana/web3.js':
         specifier: ^1.95.3
@@ -586,7 +586,7 @@ importers:
         version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/spl-type-length-value':
         specifier: 0.1.0
-        version: link:../../libraries/type-length-value/js
+        version: 0.1.0
     devDependencies:
       '@solana/web3.js':
         specifier: ^1.95.3


### PR DESCRIPTION
This is a breaking change which _removes_ the need for browsers to introduce a polyfill for `createHash`. Engines now have a built-in `SubtleCrypto#digest` which serves this purpose, polyfill-free, with [good support](https://caniuse.com/mdn-api_subtlecrypto_digest).

The reason this is a breaking change is that `createHash` is synchronous and `SubtleCrypto#digest` is async.

Related to #7351.