### PR TITLE
CI: Update token-group and token-metadata JS jobs to Node 20

### DIFF
--- a/.github/workflows/pull-request-libraries.yml
+++ b/.github/workflows/pull-request-libraries.yml
@@ -66,7 +66,7 @@ jobs:
   js-test:
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 20.5
+      NODE_VERSION: 20.x
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/.github/workflows/pull-request-token-group.yml
+++ b/.github/workflows/pull-request-token-group.yml
@@ -74,7 +74,7 @@ jobs:
   js-test:
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 16.x
+      NODE_VERSION: 20.x
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/.github/workflows/pull-request-token-metadata.yml
+++ b/.github/workflows/pull-request-token-metadata.yml
@@ -75,7 +75,7 @@ jobs:
   js-test:
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: 16.x
+      NODE_VERSION: 20.x
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}


### PR DESCRIPTION
#### Problem

The token-group and token-metadata JS packages now require at least Node v19, but the specific workflows only use v16.

#### Summary of changes

Update the CI job to v20.