### PR TITLE
Release v0.4.2 with idl-build feature

### DIFF
--- a/account-compression/programs/account-compression/Cargo.toml
+++ b/account-compression/programs/account-compression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-account-compression"
-version = "0.4.1"
+version = "0.4.2"
 description = "Solana Program Library Account Compression Program"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"


### PR DESCRIPTION
- Expose `idl-build` feature to work properly with other anchor crates