### PR TITLE
CI: Pin version of cargo-release

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -167,7 +167,7 @@ jobs:
             cargo-publish-
 
       - name: Install Cargo Release
-        run: which cargo-release || cargo install cargo-release
+        run: which cargo-release || cargo install cargo-release --version 0.25.11
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:


### PR DESCRIPTION
#### Problem

The release step in CI is failing because the latest cargo-release requires Rust 1.79, but this repo is still at 1.78.

#### Summary of changes

Pin cargo-release to 0.25.11, which is compatible with 1.78, as noted in the failing run: https://github.com/solana-labs/solana-program-library/actions/runs/11523644623/job/32082450563