### PR TITLE
remove solana-program from spl-pod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8200,11 +8200,18 @@ dependencies = [
  "borsh 1.5.1",
  "bytemuck",
  "bytemuck_derive",
+ "num-derive",
+ "num-traits",
  "serde",
  "serde_json",
+ "solana-decode-error",
+ "solana-msg",
  "solana-program",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-pubkey",
  "solana-zk-sdk",
- "spl-program-error 0.5.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -15,13 +15,20 @@ borsh = ["dep:borsh"]
 borsh = { version = "1.5.1", optional = true }
 bytemuck = { version = "1.19.0" }
 bytemuck_derive = { version = "1.8.0" }
+num-derive = "0.4"
+num-traits = "0.2"
 serde = { version = "1.0.214", optional = true }
-solana-program = "2.1.0"
+solana-decode-error = "2.1.0"
+solana-msg = "2.1.0"
+solana-program-error = "2.1.0"
+solana-program-option = "2.1.0"
+solana-pubkey = "2.1.0"
 solana-zk-sdk = "2.1.0"
-spl-program-error = { version = "0.5.0", path = "../program-error" }
+thiserror = "1.0"
 
 [dev-dependencies]
 serde_json = "1.0.132"
+solana-program = "2.1.0"
 base64 = { version = "0.22.1" }
 
 [lib]

--- a/libraries/pod/src/bytemuck.rs
+++ b/libraries/pod/src/bytemuck.rs
@@ -1,6 +1,6 @@
 //! wrappers for bytemuck functions
 
-use {bytemuck::Pod, solana_program::program_error::ProgramError};
+use {bytemuck::Pod, solana_program_error::ProgramError};
 
 /// On-chain size of a `Pod` type
 pub const fn pod_get_packed_len<T: Pod>() -> usize {

--- a/libraries/pod/src/error.rs
+++ b/libraries/pod/src/error.rs
@@ -1,8 +1,10 @@
 //! Error types
-use spl_program_error::*;
+use solana_decode_error::DecodeError;
+use solana_msg::msg;
+use solana_program_error::{PrintProgramError, ProgramError};
 
 /// Errors that may be returned by the spl-pod library.
-#[spl_program_error]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, num_derive::FromPrimitive)]
 pub enum PodSliceError {
     /// Error in checked math operation
     #[error("Error in checked math operation")]
@@ -13,4 +15,38 @@ pub enum PodSliceError {
     /// Provided byte buffer too large for expected type
     #[error("Provided byte buffer too large for expected type")]
     BufferTooLarge,
+}
+
+impl From<PodSliceError> for ProgramError {
+    fn from(e: PodSliceError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+
+impl<T> solana_decode_error::DecodeError<T> for PodSliceError {
+    fn type_of() -> &'static str {
+        "PodSliceError"
+    }
+}
+
+impl PrintProgramError for PodSliceError {
+    fn print<E>(&self)
+    where
+        E: 'static + std::error::Error
+            + DecodeError<E>
+            + PrintProgramError
+            + num_traits::FromPrimitive,
+    {
+        match self {
+            PodSliceError::CalculationFailure => {
+                msg!("Error in checked math operation")
+            }
+            PodSliceError::BufferTooSmall => {
+                msg!("Provided byte buffer too small for expected type")
+            }
+            PodSliceError::BufferTooLarge => {
+                msg!("Provided byte buffer too large for expected type")
+            }
+        }
+    }
 }

--- a/libraries/pod/src/error.rs
+++ b/libraries/pod/src/error.rs
@@ -6,6 +6,7 @@ use {
 };
 
 /// Errors that may be returned by the spl-pod library.
+#[repr(32)]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, num_derive::FromPrimitive)]
 pub enum PodSliceError {
     /// Error in checked math operation

--- a/libraries/pod/src/error.rs
+++ b/libraries/pod/src/error.rs
@@ -6,7 +6,7 @@ use {
 };
 
 /// Errors that may be returned by the spl-pod library.
-#[repr(32)]
+#[repr(u32)]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, num_derive::FromPrimitive)]
 pub enum PodSliceError {
     /// Error in checked math operation

--- a/libraries/pod/src/error.rs
+++ b/libraries/pod/src/error.rs
@@ -1,7 +1,9 @@
 //! Error types
-use solana_decode_error::DecodeError;
-use solana_msg::msg;
-use solana_program_error::{PrintProgramError, ProgramError};
+use {
+    solana_decode_error::DecodeError,
+    solana_msg::msg,
+    solana_program_error::{PrintProgramError, ProgramError},
+};
 
 /// Errors that may be returned by the spl-pod library.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, num_derive::FromPrimitive)]
@@ -32,7 +34,8 @@ impl<T> solana_decode_error::DecodeError<T> for PodSliceError {
 impl PrintProgramError for PodSliceError {
     fn print<E>(&self)
     where
-        E: 'static + std::error::Error
+        E: 'static
+            + std::error::Error
             + DecodeError<E>
             + PrintProgramError
             + num_traits::FromPrimitive,

--- a/libraries/pod/src/lib.rs
+++ b/libraries/pod/src/lib.rs
@@ -9,4 +9,6 @@ pub mod slice;
 
 // Export current sdk types for downstream users building with a different sdk
 // version
-pub use {solana_decode_error, solana_msg, solana_program_error, solana_program_option, solana_pubkey};
+pub use {
+    solana_decode_error, solana_msg, solana_program_error, solana_program_option, solana_pubkey,
+};

--- a/libraries/pod/src/lib.rs
+++ b/libraries/pod/src/lib.rs
@@ -9,4 +9,4 @@ pub mod slice;
 
 // Export current sdk types for downstream users building with a different sdk
 // version
-pub use solana_program;
+pub use {solana_decode_error, solana_msg, solana_program_error, solana_program_option, solana_pubkey};

--- a/libraries/pod/src/option.rs
+++ b/libraries/pod/src/option.rs
@@ -8,11 +8,9 @@
 
 use {
     bytemuck::{Pod, Zeroable},
-    solana_program::{
-        program_error::ProgramError,
-        program_option::COption,
-        pubkey::{Pubkey, PUBKEY_BYTES},
-    },
+    solana_program_error::ProgramError,
+    solana_program_option::COption,
+    solana_pubkey::{Pubkey, PUBKEY_BYTES},
 };
 
 /// Trait for types that can be `None`.

--- a/libraries/pod/src/optional_keys.rs
+++ b/libraries/pod/src/optional_keys.rs
@@ -3,7 +3,9 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {
     bytemuck_derive::{Pod, Zeroable},
-    solana_program::{program_error::ProgramError, program_option::COption, pubkey::Pubkey},
+    solana_program_error::ProgramError,
+    solana_program_option::COption,
+    solana_pubkey::Pubkey,
     solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey,
 };
 #[cfg(feature = "serde-traits")]
@@ -220,7 +222,7 @@ mod tests {
         super::*,
         crate::bytemuck::pod_from_bytes,
         base64::{prelude::BASE64_STANDARD, Engine},
-        solana_program::pubkey::PUBKEY_BYTES,
+        solana_pubkey::PUBKEY_BYTES,
     };
 
     #[test]

--- a/libraries/pod/src/slice.rs
+++ b/libraries/pod/src/slice.rs
@@ -9,7 +9,7 @@ use {
         primitives::PodU32,
     },
     bytemuck::Pod,
-    solana_program::program_error::ProgramError,
+    solana_program_error::ProgramError,
 };
 
 const LENGTH_SIZE: usize = std::mem::size_of::<PodU32>();


### PR DESCRIPTION
This required replacing `#[spl_program_error]` with inline impls. I think it is hard or perhaps impossible to decouple `spl-program-error` from `solana_program` without breaking changes.

For now there will still be an indirect solana-program dep via solana-zk-sdk