### PR TITLE
js: Update libs from rc.1 to rc.2

### DIFF
--- a/.github/workflows/pull-request-js.yml
+++ b/.github/workflows/pull-request-js.yml
@@ -3,7 +3,6 @@ name: Pull Request JS
 on:
   pull_request:
     paths:
-      - 'account-compression/sdk/**'
       - 'libraries/type-length-value/js/**'
       - 'memo/js/**'
       - 'name-service/js/**'
@@ -19,7 +18,6 @@ on:
   push:
     branches: [master]
     paths:
-      - 'account-compression/sdk/**'
       - 'libraries/type-length-value/js/**'
       - 'memo/js/**'
       - 'single-pool/js/**'
@@ -43,7 +41,6 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
         package:
           [
-            account-compression,
             memo,
             name-service,
             stake-pool,

--- a/libraries/type-length-value/js/package.json
+++ b/libraries/type-length-value/js/package.json
@@ -43,7 +43,7 @@
         "watch": "tsc --build --verbose --watch tsconfig.all.json"
     },
     "dependencies": {
-        "@solana/assertions": "^2.0.0-rc.1",
+        "@solana/assertions": "^2.0.0-rc.2",
         "buffer": "^6.0.3"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "private": true,
     "workspaces": [
-        "account-compression/sdk",
         "libraries/type-length-value/js",
         "memo/js",
         "single-pool/js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
   libraries/type-length-value/js:
     dependencies:
       '@solana/assertions':
-        specifier: ^2.0.0-rc.1
-        version: 2.0.0-rc.1(typescript@5.6.3)
+        specifier: ^2.0.0-rc.2
+        version: 2.0.0-rc.2(typescript@5.6.3)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -310,8 +310,8 @@ importers:
   single-pool/js/packages/classic:
     dependencies:
       '@solana/addresses':
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/spl-single-pool':
         specifier: 1.0.0
         version: link:../modern
@@ -347,14 +347,14 @@ importers:
   single-pool/js/packages/modern:
     dependencies:
       '@solana/addresses':
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/instructions':
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(typescript@5.6.3)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(typescript@5.6.3)
       '@solana/transaction-messages':
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     devDependencies:
       '@types/node':
         specifier: ^22.8.5
@@ -460,8 +460,8 @@ importers:
   token-group/js:
     dependencies:
       '@solana/codecs':
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     devDependencies:
       '@solana/spl-type-length-value':
         specifier: 0.2.0
@@ -582,8 +582,8 @@ importers:
   token-metadata/js:
     dependencies:
       '@solana/codecs':
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     devDependencies:
       '@solana/spl-type-length-value':
         specifier: 0.2.0
@@ -711,8 +711,8 @@ importers:
         version: 6.0.3
     devDependencies:
       '@solana/codecs-strings':
-        specifier: 2.0.0-rc.1
-        version: 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/spl-memo':
         specifier: 0.2.4
         version: link:../../memo/js
@@ -2217,26 +2217,28 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@solana/addresses@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
-    resolution: {integrity: sha512-g31KrLZdECjAKceShlGoYxnWDmEVklpjPs8xOtnj/HWupEk+Mds4vtmTACTAeJkWZW/3x+z0aexMtO86MKA47g==}
+  /@solana/addresses@2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+    resolution: {integrity: sha512-B8Ctkc1Ks/cw1wYkwyuQAUoNzlOs5Yc2bWQoPFe0SJQ5EzwqAip8TDel+cvJEeaCRBQ2imApLfu8Grz7TqVn4Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/assertions': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/assertions': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/assertions@2.0.0-rc.1(typescript@5.6.3):
-    resolution: {integrity: sha512-dvxYCUB7ftZa5lWcsyMYLsGm204H6yVN8Q3ngluMG0rhTtScMBRklVg7Vs39ISwJOkJWJPGToaZ7DjNJ83bm1Q==}
+  /@solana/assertions@2.0.0-rc.2(typescript@5.6.3):
+    resolution: {integrity: sha512-qDeQc9MV3E1L8kOWXT1LjOxbquEWlxshKNQULgfsfrtsr6SucEaWHc6oBwdVMCj80iR/VzfAtOPB9a5HKXHp3Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
     dev: false
 
@@ -2260,63 +2262,69 @@ packages:
     dependencies:
       buffer: 6.0.3
 
-  /@solana/codecs-core@2.0.0-rc.1(typescript@5.6.3):
-    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+  /@solana/codecs-core@2.0.0-rc.2(typescript@5.6.3):
+    resolution: {integrity: sha512-UHSdAmbiFYuCwb2UmYZkOIj2oTKuYqje1LZ1VWCdnpp2qf+XAGbxIHyL/auV91/nK8iggL9417BMS2Q3AfMzFg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
 
-  /@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.6.3):
-    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
+  /@solana/codecs-data-structures@2.0.0-rc.2(typescript@5.6.3):
+    resolution: {integrity: sha512-W2CZHIycQhQjU2nawC2Yes/cfrk4wT+vaOYZgeAIBZUeW2QRO/GLhJzcQbQ675xYo8Qxpv5nRwlRL8Ux4Q6RyQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
     dev: false
 
-  /@solana/codecs-numbers@2.0.0-rc.1(typescript@5.6.3):
-    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
+  /@solana/codecs-numbers@2.0.0-rc.2(typescript@5.6.3):
+    resolution: {integrity: sha512-cQoTXVYF+nQjIh6VtrD4i7rfyJL0q46TMOd64+J/+2bQG2UT4Cwwo0b2lHuqtQr+2+BYjHPFDSNLaa3IWpPNog==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
 
-  /@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
-    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+  /@solana/codecs-strings@2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+    resolution: {integrity: sha512-EAFAkztLYqOwHG+C4pbRQn8GcPi5yW3lh162m+OSKJJdcMAnpFBG4jN7eJPVgyRMfToxknjFB8veZN7XmNdqqg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.6.3
 
-  /@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
-    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
+  /@solana/codecs@2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+    resolution: {integrity: sha512-JUAkbnfm2wf7+zwRVY8d0Aptmd8z/OCHH14zIAEafxQ3gzy8WdUD09/+GcZNOGfzHDNbsqpzg3C+nzM8jUxO6A==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/options': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/errors@2.0.0-rc.1(typescript@5.6.3):
-    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
+  /@solana/errors@2.0.0-rc.2(typescript@5.6.3):
+    resolution: {integrity: sha512-2NPRQYOLwpwP2J4KC0+Vc+qmwTGcu6VrKA9iRBLP0axR+49er9AqpoK3EowTmt0BvAvyArOJRuaPRIFMQI2IdA==}
+    engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -2373,33 +2381,36 @@ packages:
       typescript: 5.6.3
     dev: true
 
-  /@solana/functional@2.0.0-rc.1(typescript@5.6.3):
-    resolution: {integrity: sha512-BmedS5o8HTlU8/NA22I6urJqat9QYIw0oH6rKdMMBisDwX7MtgJhe38W8iLP7QCcxoJeS4526qaD8uD62+Pheg==}
+  /@solana/functional@2.0.0-rc.2(typescript@5.6.3):
+    resolution: {integrity: sha512-aEc3kHibD6Da9w1F/17+TZFmH0WaR4f2ve0AMeT89tNK37rOYNB4DyMti38I6h0PlS7LxogxspvF4rAWMuOwFQ==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
       typescript: 5.6.3
     dev: false
 
-  /@solana/instructions@2.0.0-rc.1(typescript@5.6.3):
-    resolution: {integrity: sha512-zkfL4WBHPbkMrYsuGZc/sekPa/oALIVvVGUw/gwAervMeLZ34cWCUE6WC2uUUh+bq3OFq0/FSFhAg2YbHHDyUw==}
+  /@solana/instructions@2.0.0-rc.2(typescript@5.6.3):
+    resolution: {integrity: sha512-Y8oBKcPoNWrqRgsueDboIuG8lxvn2dsi0yoJvVAxudcLlqugNvQJYOT+Z76zMIxP/76FGsryKvAyvDAXdhlY8Q==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
     dev: false
 
-  /@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
-    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
+  /@solana/options@2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+    resolution: {integrity: sha512-kYD8k1ctAwyU5ihE4DlHqgqiP8k71TvtKOyxY/vGr6BJZ1paVgJpNLxapwzurJVbYlaqzRtqkTsb5iyFQeXAsg==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -2413,34 +2424,36 @@ packages:
       prettier: 3.3.3
     dev: true
 
-  /@solana/rpc-types@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
-    resolution: {integrity: sha512-EcGx9VXqA0+uYEdaa1lKTaGBVxLyNL8nkecE4GkqQ+ntRyYlNBPecd4b8siQGSleUQa+Tk/VSPUawSkHqNTLug==}
+  /@solana/rpc-types@2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+    resolution: {integrity: sha512-1fieQLjJK/KifO47XzDwsLJnx1D0cc+SB1EXyCnaz3aRdlLlIoP/p6NG+OHyIow1LrDZrAvoBr66G68ruPV6qA==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/addresses': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
+      '@solana/addresses': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-strings': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/transaction-messages@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
-    resolution: {integrity: sha512-pZTetOtRDwfuK/fyE8FKbtRsLQOTgEIQld3tskB85npUHaEgrnCYzp3nJtMhKOLel3w3f/27VtWLNSrRyyAiew==}
+  /@solana/transaction-messages@2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3):
+    resolution: {integrity: sha512-1nhkWvtPSyHS1nHMnhVsX82IwQDaO6IhU4a445OGDbSVrYpkZgJ5f6iE+NcjNcZPx8kklO8ynpM15lObvoTxbw==}
+    engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
     dependencies:
-      '@solana/addresses': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/functional': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/instructions': 2.0.0-rc.1(typescript@5.6.3)
-      '@solana/rpc-types': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/addresses': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/codecs-numbers': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/errors': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/functional': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/instructions': 2.0.0-rc.2(typescript@5.6.3)
+      '@solana/rpc-types': 2.0.0-rc.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
-  - "account-compression/sdk"
   - "libraries/type-length-value/js"
   - "memo/js"
   - "name-service/js"

--- a/single-pool/js/packages/classic/package.json
+++ b/single-pool/js/packages/classic/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.95.4",
-    "@solana/addresses": "2.0.0-rc.1",
+    "@solana/addresses": "2.0.0-rc.2",
     "@solana/spl-single-pool": "1.0.0"
   },
   "ava": {

--- a/single-pool/js/packages/modern/package.json
+++ b/single-pool/js/packages/modern/package.json
@@ -22,8 +22,8 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@solana/addresses": "2.0.0-rc.1",
-    "@solana/instructions": "2.0.0-rc.1",
-    "@solana/transaction-messages": "2.0.0-rc.1"
+    "@solana/addresses": "2.0.0-rc.2",
+    "@solana/instructions": "2.0.0-rc.2",
+    "@solana/transaction-messages": "2.0.0-rc.2"
   }
 }

--- a/token-group/js/package.json
+++ b/token-group/js/package.json
@@ -46,7 +46,7 @@
         "@solana/web3.js": "^1.95.4"
     },
     "dependencies": {
-        "@solana/codecs": "2.0.0-rc.1"
+        "@solana/codecs": "2.0.0-rc.2"
     },
     "devDependencies": {
         "@solana/spl-type-length-value": "0.2.0",

--- a/token-metadata/js/package.json
+++ b/token-metadata/js/package.json
@@ -46,7 +46,7 @@
         "@solana/web3.js": "^1.95.4"
     },
     "dependencies": {
-        "@solana/codecs": "2.0.0-rc.1"
+        "@solana/codecs": "2.0.0-rc.2"
     },
     "devDependencies": {
         "@solana/spl-type-length-value": "0.2.0",

--- a/token/js/package.json
+++ b/token/js/package.json
@@ -60,7 +60,7 @@
         "buffer": "^6.0.3"
     },
     "devDependencies": {
-        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.2",
         "@solana/spl-memo": "0.2.4",
         "@solana/web3.js": "^1.95.4",
         "@types/chai-as-promised": "^8.0.1",


### PR DESCRIPTION
#### Problem

`@solana/web3.js@2` has released rc.2, but the SPL JS libs don't use it.

#### Summary of changes

Use it!