### PR TITLE
remove solana-program from spl-memo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8143,8 +8143,13 @@ dependencies = [
 name = "spl-memo"
 version = "5.0.0"
 dependencies = [
- "solana-program",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
  "solana-program-test",
+ "solana-pubkey",
  "solana-sdk",
 ]
 

--- a/memo/program/Cargo.toml
+++ b/memo/program/Cargo.toml
@@ -12,7 +12,12 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-solana-program = "2.1.0"
+solana-account-info = "2.1.0"
+solana-instruction = "2.1.0"
+solana-msg = "2.1.0"
+solana-program-entrypoint = "2.1.0"
+solana-program-error = "2.1.0"
+solana-pubkey = "2.1.0"
 
 [dev-dependencies]
 solana-program-test = "2.1.0"

--- a/memo/program/src/entrypoint.rs
+++ b/memo/program/src/entrypoint.rs
@@ -2,9 +2,12 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
+use {
+    solana_account_info::AccountInfo, solana_program_entrypoint::ProgramResult,
+    solana_pubkey::Pubkey,
+};
 
-solana_program::entrypoint!(process_instruction);
+solana_program_entrypoint::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/memo/program/src/lib.rs
+++ b/memo/program/src/lib.rs
@@ -9,18 +9,21 @@ pub mod processor;
 
 // Export current sdk types for downstream users building with a different sdk
 // version
-pub use solana_program;
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
+pub use {
+    solana_account_info, solana_instruction, solana_msg, solana_program_entrypoint,
+    solana_program_error, solana_pubkey,
+};
+use {
+    solana_instruction::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
 };
 
 /// Legacy symbols from Memo v1
 pub mod v1 {
-    solana_program::declare_id!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
+    solana_pubkey::declare_id!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
 }
 
-solana_program::declare_id!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+solana_pubkey::declare_id!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
 
 /// Build a memo instruction, possibly signed
 ///

--- a/memo/program/src/processor.rs
+++ b/memo/program/src/processor.rs
@@ -1,11 +1,8 @@
 //! Program state processor
 
 use {
-    solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
-        pubkey::Pubkey,
-    },
-    std::str::from_utf8,
+    solana_account_info::AccountInfo, solana_msg::msg, solana_program_entrypoint::ProgramResult,
+    solana_program_error::ProgramError, solana_pubkey::Pubkey, std::str::from_utf8,
 };
 
 /// Instruction processor


### PR DESCRIPTION
Breaking change: replaces the solana_program re-export with re-exports of the smaller crates