### PR TITLE
remove solana-program from token-group-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8720,7 +8720,6 @@ dependencies = [
  "solana-sha256-hasher",
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
- "spl-program-error 0.5.0",
  "spl-type-length-value 0.6.0",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8709,11 +8709,20 @@ name = "spl-token-group-interface"
 version = "0.4.2"
 dependencies = [
  "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
  "solana-program",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sha256-hasher",
  "spl-discriminator 0.3.0",
  "spl-pod 0.4.0",
  "spl-program-error 0.5.0",
  "spl-type-length-value 0.6.0",
+ "thiserror",
 ]
 
 [[package]]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -9,12 +9,21 @@ edition = "2021"
 
 [dependencies]
 bytemuck = "1.19.0"
+num-derive = "0.4"
+num-traits = "0.2"
+solana-decode-error = "2.1.0"
+solana-instruction = "2.1.0"
+solana-msg = "2.1.0"
 solana-program = "2.1.0"
+solana-program-error = "2.1.0"
+solana-pubkey = "2.1.0"
 spl-discriminator = { version = "0.3.0" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.4.0", path = "../../libraries/pod", features = ["borsh"] }
 spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
+thiserror = "1.0"
 
 [dev-dependencies]
+solana-sha256-hasher = "2.1.0"
 spl-type-length-value = { version = "0.6.0", path = "../../libraries/type-length-value", features = ["derive"] }
 
 [lib]

--- a/token-group/interface/Cargo.toml
+++ b/token-group/interface/Cargo.toml
@@ -19,7 +19,6 @@ solana-program-error = "2.1.0"
 solana-pubkey = "2.1.0"
 spl-discriminator = { version = "0.3.0" , path = "../../libraries/discriminator" }
 spl-pod = { version = "0.4.0", path = "../../libraries/pod", features = ["borsh"] }
-spl-program-error = { version = "0.5.0" , path = "../../libraries/program-error" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/token-group/interface/src/error.rs
+++ b/token-group/interface/src/error.rs
@@ -1,13 +1,18 @@
 //! Interface error types
 
-use spl_program_error::*;
+use {
+    solana_decode_error::DecodeError,
+    solana_msg::msg,
+    solana_program_error::{PrintProgramError, ProgramError},
+};
 
 /// Errors that may be returned by the interface.
-#[spl_program_error(hash_error_code_start = 3_406_457_176)]
+#[repr(u32)]
+#[derive(Clone, Debug, Eq, thiserror::Error, num_derive::FromPrimitive, PartialEq)]
 pub enum TokenGroupError {
     /// Size is greater than proposed max size
     #[error("Size is greater than proposed max size")]
-    SizeExceedsNewMaxSize,
+    SizeExceedsNewMaxSize = 3_406_457_176,
     /// Size is greater than max size
     #[error("Size is greater than max size")]
     SizeExceedsMaxSize,
@@ -23,4 +28,48 @@ pub enum TokenGroupError {
     /// Member account should not be the same as the group account
     #[error("Member account should not be the same as the group account")]
     MemberAccountIsGroupAccount,
+}
+
+impl From<TokenGroupError> for ProgramError {
+    fn from(e: TokenGroupError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+
+impl<T> DecodeError<T> for TokenGroupError {
+    fn type_of() -> &'static str {
+        "TokenGroupError"
+    }
+}
+
+impl PrintProgramError for TokenGroupError {
+    fn print<E>(&self)
+    where
+        E: 'static
+            + std::error::Error
+            + DecodeError<E>
+            + PrintProgramError
+            + num_traits::FromPrimitive,
+    {
+        match self {
+            TokenGroupError::SizeExceedsNewMaxSize => {
+                msg!("Size is greater than proposed max size")
+            }
+            TokenGroupError::SizeExceedsMaxSize => {
+                msg!("Size is greater than max size")
+            }
+            TokenGroupError::ImmutableGroup => {
+                msg!("Group is immutable")
+            }
+            TokenGroupError::IncorrectMintAuthority => {
+                msg!("Incorrect mint authority has signed the instruction",)
+            }
+            TokenGroupError::IncorrectUpdateAuthority => {
+                msg!("Incorrect update authority has signed the instruction",)
+            }
+            TokenGroupError::MemberAccountIsGroupAccount => {
+                msg!("Member account should not be the same as the group account",)
+            }
+        }
+    }
 }

--- a/token-group/interface/src/instruction.rs
+++ b/token-group/interface/src/instruction.rs
@@ -2,11 +2,9 @@
 
 use {
     bytemuck::{Pod, Zeroable},
-    solana_program::{
-        instruction::{AccountMeta, Instruction},
-        program_error::ProgramError,
-        pubkey::Pubkey,
-    },
+    solana_instruction::{AccountMeta, Instruction},
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
     spl_discriminator::{ArrayDiscriminator, SplDiscriminate},
     spl_pod::{
         bytemuck::{pod_bytes_of, pod_from_bytes},
@@ -243,7 +241,7 @@ pub fn initialize_member(
 
 #[cfg(test)]
 mod test {
-    use {super::*, crate::NAMESPACE, solana_program::hash};
+    use {super::*, crate::NAMESPACE, solana_sha256_hasher::hashv};
 
     fn instruction_pack_unpack<I>(instruction: TokenGroupInstruction, discriminator: &[u8], data: I)
     where
@@ -265,7 +263,7 @@ mod test {
             max_size: 100.into(),
         };
         let instruction = TokenGroupInstruction::InitializeGroup(data);
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:initialize_token_group").as_bytes()]);
+        let preimage = hashv(&[format!("{NAMESPACE}:initialize_token_group").as_bytes()]);
         let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
         instruction_pack_unpack::<InitializeGroup>(instruction, discriminator, data);
     }
@@ -276,7 +274,7 @@ mod test {
             max_size: 200.into(),
         };
         let instruction = TokenGroupInstruction::UpdateGroupMaxSize(data);
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_group_max_size").as_bytes()]);
+        let preimage = hashv(&[format!("{NAMESPACE}:update_group_max_size").as_bytes()]);
         let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
         instruction_pack_unpack::<UpdateGroupMaxSize>(instruction, discriminator, data);
     }
@@ -287,7 +285,7 @@ mod test {
             new_authority: OptionalNonZeroPubkey::default(),
         };
         let instruction = TokenGroupInstruction::UpdateGroupAuthority(data);
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:update_authority").as_bytes()]);
+        let preimage = hashv(&[format!("{NAMESPACE}:update_authority").as_bytes()]);
         let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
         instruction_pack_unpack::<UpdateGroupAuthority>(instruction, discriminator, data);
     }
@@ -296,7 +294,7 @@ mod test {
     fn initialize_member_pack() {
         let data = InitializeMember {};
         let instruction = TokenGroupInstruction::InitializeMember(data);
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:initialize_member").as_bytes()]);
+        let preimage = hashv(&[format!("{NAMESPACE}:initialize_member").as_bytes()]);
         let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
         instruction_pack_unpack::<InitializeMember>(instruction, discriminator, data);
     }

--- a/token-group/interface/src/state.rs
+++ b/token-group/interface/src/state.rs
@@ -88,7 +88,7 @@ mod tests {
     use {
         super::*,
         crate::NAMESPACE,
-        solana_program::hash,
+        solana_sha256_hasher::hashv,
         spl_discriminator::ArrayDiscriminator,
         spl_type_length_value::state::{TlvState, TlvStateBorrowed, TlvStateMut},
         std::mem::size_of,
@@ -96,12 +96,12 @@ mod tests {
 
     #[test]
     fn discriminators() {
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:group").as_bytes()]);
+        let preimage = hashv(&[format!("{NAMESPACE}:group").as_bytes()]);
         let discriminator =
             ArrayDiscriminator::try_from(&preimage.as_ref()[..ArrayDiscriminator::LENGTH]).unwrap();
         assert_eq!(TokenGroup::SPL_DISCRIMINATOR, discriminator);
 
-        let preimage = hash::hashv(&[format!("{NAMESPACE}:member").as_bytes()]);
+        let preimage = hashv(&[format!("{NAMESPACE}:member").as_bytes()]);
         let discriminator =
             ArrayDiscriminator::try_from(&preimage.as_ref()[..ArrayDiscriminator::LENGTH]).unwrap();
         assert_eq!(TokenGroupMember::SPL_DISCRIMINATOR, discriminator);


### PR DESCRIPTION
Updated imports and replace spl_program_error usage with inline impls