### PR TITLE
CI: Purge ubuntu runner for clippy step

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,6 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Remove unneeded packages for more space
+        run: bash ./ci/warning/purge-ubuntu-runner.sh
+
       - name: Set env vars
         run: |
           source ci/rust-version.sh


### PR DESCRIPTION
#### Problem

It looks like the clippy CI step is running out of space on the build machine.

#### Summary of changes

Use the purge script for the clippy step.