### PR TITLE
pod: remove solana-program from dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8220,7 +8220,6 @@ dependencies = [
  "serde_json",
  "solana-decode-error",
  "solana-msg",
- "solana-program",
  "solana-program-error",
  "solana-program-option",
  "solana-pubkey",

--- a/libraries/pod/Cargo.toml
+++ b/libraries/pod/Cargo.toml
@@ -28,7 +28,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 serde_json = "1.0.132"
-solana-program = "2.1.0"
 base64 = { version = "0.22.1" }
 
 [lib]

--- a/libraries/pod/src/option.rs
+++ b/libraries/pod/src/option.rs
@@ -128,36 +128,36 @@ impl Nullable for Pubkey {
 
 #[cfg(test)]
 mod tests {
-
-    use {super::*, crate::bytemuck::pod_slice_from_bytes, solana_program::sysvar};
+    use {super::*, crate::bytemuck::pod_slice_from_bytes};
+    const ID: Pubkey = Pubkey::from_str_const("TestSysvar111111111111111111111111111111111");
 
     #[test]
     fn test_pod_option_pubkey() {
-        let some_pubkey = PodOption::from(sysvar::ID);
-        assert_eq!(some_pubkey.get(), Some(sysvar::ID));
+        let some_pubkey = PodOption::from(ID);
+        assert_eq!(some_pubkey.get(), Some(ID));
 
         let none_pubkey = PodOption::from(Pubkey::default());
         assert_eq!(none_pubkey.get(), None);
 
         let mut data = Vec::with_capacity(64);
-        data.extend_from_slice(sysvar::ID.as_ref());
+        data.extend_from_slice(ID.as_ref());
         data.extend_from_slice(&[0u8; 32]);
 
         let values = pod_slice_from_bytes::<PodOption<Pubkey>>(&data).unwrap();
-        assert_eq!(values[0], PodOption::from(sysvar::ID));
+        assert_eq!(values[0], PodOption::from(ID));
         assert_eq!(values[1], PodOption::from(Pubkey::default()));
 
-        let option_pubkey = Some(sysvar::ID);
+        let option_pubkey = Some(ID);
         let pod_option_pubkey: PodOption<Pubkey> = option_pubkey.try_into().unwrap();
-        assert_eq!(pod_option_pubkey, PodOption::from(sysvar::ID));
+        assert_eq!(pod_option_pubkey, PodOption::from(ID));
         assert_eq!(
             pod_option_pubkey,
             PodOption::try_from(option_pubkey).unwrap()
         );
 
-        let coption_pubkey = COption::Some(sysvar::ID);
+        let coption_pubkey = COption::Some(ID);
         let pod_option_pubkey: PodOption<Pubkey> = coption_pubkey.try_into().unwrap();
-        assert_eq!(pod_option_pubkey, PodOption::from(sysvar::ID));
+        assert_eq!(pod_option_pubkey, PodOption::from(ID));
         assert_eq!(
             pod_option_pubkey,
             PodOption::try_from(coption_pubkey).unwrap()
@@ -166,11 +166,8 @@ mod tests {
 
     #[test]
     fn test_try_from_option() {
-        let some_pubkey = Some(sysvar::ID);
-        assert_eq!(
-            PodOption::try_from(some_pubkey).unwrap(),
-            PodOption(sysvar::ID)
-        );
+        let some_pubkey = Some(ID);
+        assert_eq!(PodOption::try_from(some_pubkey).unwrap(), PodOption(ID));
 
         let none_pubkey = None;
         assert_eq!(


### PR DESCRIPTION
#### Problem

There's still a dev-dependency on solana-program in spl-pod, but it's only used for a hardcoded pubkey.

#### Summary of changes

Use another hardcoded pubkey and remove the dev-dependency