### PR TITLE
instruction-padding: Remove solana-program dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8104,9 +8104,16 @@ name = "spl-instruction-padding"
 version = "0.2.0"
 dependencies = [
  "num_enum",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
  "solana-program",
+ "solana-program-entrypoint",
+ "solana-program-error",
  "solana-program-test",
+ "solana-pubkey",
  "solana-sdk",
+ "static_assertions",
 ]
 
 [[package]]

--- a/instruction-padding/program/Cargo.toml
+++ b/instruction-padding/program/Cargo.toml
@@ -14,11 +14,18 @@ test-sbf = []
 
 [dependencies]
 num_enum = "0.7.3"
-solana-program = "2.1.0"
+solana-account-info = "2.1.0"
+solana-cpi = "2.1.0"
+solana-instruction = { version = "2.1.0", features = ["std"] }
+solana-program-entrypoint = "2.1.0"
+solana-program-error = "2.1.0"
+solana-pubkey = "2.1.0"
 
 [dev-dependencies]
+solana-program = "2.1.0"
 solana-program-test = "2.1.0"
 solana-sdk = "2.1.0"
+static_assertions = "1.1.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/instruction-padding/program/src/entrypoint.rs
+++ b/instruction-padding/program/src/entrypoint.rs
@@ -2,9 +2,11 @@
 
 #![cfg(not(feature = "no-entrypoint"))]
 
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
+use {
+    solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
+};
 
-solana_program::entrypoint!(process_instruction);
+solana_program_entrypoint::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/instruction-padding/program/src/instruction.rs
+++ b/instruction-padding/program/src/instruction.rs
@@ -2,14 +2,25 @@
 
 use {
     num_enum::{IntoPrimitive, TryFromPrimitive},
-    solana_program::{
-        instruction::{AccountMeta, Instruction},
-        program_error::ProgramError,
-        pubkey::Pubkey,
-        syscalls::{MAX_CPI_ACCOUNT_INFOS, MAX_CPI_INSTRUCTION_DATA_LEN},
-    },
+    solana_instruction::{AccountMeta, Instruction},
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
     std::{convert::TryInto, mem::size_of},
 };
+
+const MAX_CPI_ACCOUNT_INFOS: usize = 128;
+const MAX_CPI_INSTRUCTION_DATA_LEN: u64 = 10 * 1024;
+
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    MAX_CPI_ACCOUNT_INFOS,
+    solana_program::syscalls::MAX_CPI_ACCOUNT_INFOS
+);
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    MAX_CPI_INSTRUCTION_DATA_LEN,
+    solana_program::syscalls::MAX_CPI_INSTRUCTION_DATA_LEN
+);
 
 /// Instructions supported by the padding program, which takes in additional
 /// account data or accounts and does nothing with them. It's meant for testing

--- a/instruction-padding/program/src/lib.rs
+++ b/instruction-padding/program/src/lib.rs
@@ -2,5 +2,4 @@ mod entrypoint;
 pub mod instruction;
 pub mod processor;
 
-pub use solana_program;
-solana_program::declare_id!("iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF");
+solana_pubkey::declare_id!("iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF");

--- a/instruction-padding/program/src/lib.rs
+++ b/instruction-padding/program/src/lib.rs
@@ -2,4 +2,8 @@ mod entrypoint;
 pub mod instruction;
 pub mod processor;
 
+pub use {
+    solana_account_info, solana_cpi, solana_instruction, solana_program_entrypoint,
+    solana_program_error, solana_pubkey,
+};
 solana_pubkey::declare_id!("iXpADd6AW1k5FaaXum5qHbSqyd7TtoN6AD7suVa83MF");

--- a/instruction-padding/program/src/processor.rs
+++ b/instruction-padding/program/src/processor.rs
@@ -1,13 +1,10 @@
 use {
     crate::instruction::{PadInstruction, WrapData},
-    solana_program::{
-        account_info::AccountInfo,
-        entrypoint::ProgramResult,
-        instruction::{AccountMeta, Instruction},
-        program::invoke,
-        program_error::ProgramError,
-        pubkey::Pubkey,
-    },
+    solana_account_info::AccountInfo,
+    solana_cpi::invoke,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_program_error::{ProgramError, ProgramResult},
+    solana_pubkey::Pubkey,
     std::convert::TryInto,
 };
 


### PR DESCRIPTION
#### Problem

The instruction-padding program still has an explicit dependency on solana-program, but it isn't needed.

#### Summary of changes

Use the component crates instead. Some of the syscall consts aren't available yet outside of solana-program, but it was easy to add a static assertion for those.

The program build is _lightning fast_ with this!