### PR TITLE
CI: Purge runner during clippy step for publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Remove unneeded packages for more space
+        run: bash ./ci/warning/purge-ubuntu-runner.sh
+
       - name: Set env vars
         run: |
           source ci/rust-version.sh


### PR DESCRIPTION
#### Problem

The clippy step is running out space during the publish workflow.

#### Summary of changes

Same as #7432, but for the publish workflow.