### PR TITLE
associated-token-account-client: Remove solana-program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7781,7 +7781,9 @@ dependencies = [
 name = "spl-associated-token-account-client"
 version = "1.0.0"
 dependencies = [
+ "solana-instruction",
  "solana-program",
+ "solana-pubkey",
 ]
 
 [[package]]

--- a/associated-token-account/client/Cargo.toml
+++ b/associated-token-account/client/Cargo.toml
@@ -8,6 +8,10 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
+solana-instruction = { version = "2.1.0", features = ["std"] }
+solana-pubkey = { version = "2.1.0", features = ["curve25519"] }
+
+[dev-dependencies]
 solana-program = "2.1.0"
 
 [package.metadata.docs.rs]

--- a/associated-token-account/client/src/address.rs
+++ b/associated-token-account/client/src/address.rs
@@ -1,6 +1,6 @@
 //! Address derivation functions
 
-use solana_program::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 /// Derives the associated token account address and bump seed
 /// for the given wallet address, token mint and token program id
@@ -19,7 +19,7 @@ pub fn get_associated_token_address_and_bump_seed(
 }
 
 mod inline_spl_token {
-    solana_program::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    solana_pubkey::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 }
 
 /// Derives the associated token account address for the given wallet address

--- a/associated-token-account/client/src/instruction.rs
+++ b/associated-token-account/client/src/instruction.rs
@@ -1,12 +1,11 @@
 //! Instruction creators for the program
 use {
     crate::{address::get_associated_token_address_with_program_id, program::id},
-    solana_program::{
-        instruction::{AccountMeta, Instruction},
-        pubkey::Pubkey,
-        system_program,
-    },
+    solana_instruction::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
 };
+
+const SYSTEM_PROGRAM_ID: Pubkey = Pubkey::from_str_const("11111111111111111111111111111111");
 
 fn build_associated_token_account_instruction(
     funding_address: &Pubkey,
@@ -29,7 +28,7 @@ fn build_associated_token_account_instruction(
             AccountMeta::new(associated_account_address, false),
             AccountMeta::new_readonly(*wallet_address, false),
             AccountMeta::new_readonly(*token_mint_address, false),
-            AccountMeta::new_readonly(system_program::id(), false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
             AccountMeta::new_readonly(*token_program_id, false),
         ],
         data: vec![instruction],
@@ -103,5 +102,15 @@ pub fn recover_nested(
             AccountMeta::new_readonly(*token_program_id, false),
         ],
         data: vec![2], // AssociatedTokenAccountInstruction::RecoverNested
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_program::system_program};
+
+    #[test]
+    fn system_program_id() {
+        assert_eq!(system_program::id(), SYSTEM_PROGRAM_ID);
     }
 }

--- a/associated-token-account/client/src/lib.rs
+++ b/associated-token-account/client/src/lib.rs
@@ -7,5 +7,5 @@ pub mod instruction;
 
 /// Module defining the program id
 pub mod program {
-    solana_program::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+    solana_pubkey::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 }


### PR DESCRIPTION
#### Problem

The ATA client crate still uses solana-program, but it doesn't need it.

#### Summary of changes

Remove its usage, but it's still needed in dev-dependencies until the system program client has been extracted.