### PR TITLE
token-cli: Add unreachable pattern for future change

### DIFF
--- a/token/cli/src/output.rs
+++ b/token/cli/src/output.rs
@@ -991,6 +991,9 @@ fn display_ui_extension(
             "  Unparseable extension:",
             "Consider upgrading to a newer version of spl-token",
         ),
+        // remove when upgrading v2.1.1+ and match on ConfidentialMintBurn
+        #[allow(unreachable_patterns)]
+        _ => Ok(()),
     }
 }
 


### PR DESCRIPTION
#### Problem

The downstream job in https://github.com/anza-xyz/agave/pull/3431 is failing because of the new addition to the `UiExtension` enum.

#### Summary of changes

We've done this before: temporarily add a wildcard pattern so that the downstream job passes.