### PR TITLE
[token-cli] Remove `is_amount_or_all`, `is_amount`, and `is_parsable` validators

### DIFF
--- a/token/cli/src/bench.rs
+++ b/token/cli/src/bench.rs
@@ -1,7 +1,7 @@
 /// The `bench` subcommand
 use {
     crate::{clap_app::Error, command::CommandResult, config::Config},
-    clap::{value_t_or_exit, ArgMatches},
+    clap::ArgMatches,
     solana_clap_v3_utils::input_parsers::{pubkey_of_signer, Amount},
     solana_client::{
         nonblocking::rpc_client::RpcClient, rpc_client::RpcClient as BlockingRpcClient,

--- a/token/cli/src/bench.rs
+++ b/token/cli/src/bench.rs
@@ -2,7 +2,7 @@
 use {
     crate::{clap_app::Error, command::CommandResult, config::Config},
     clap::{value_t_or_exit, ArgMatches},
-    solana_clap_v3_utils::input_parsers::pubkey_of_signer,
+    solana_clap_v3_utils::input_parsers::{pubkey_of_signer, Amount},
     solana_client::{
         nonblocking::rpc_client::RpcClient, rpc_client::RpcClient as BlockingRpcClient,
         tpu_client::TpuClient, tpu_client::TpuClientConfig,
@@ -58,7 +58,7 @@ pub(crate) async fn bench_process_command(
                 .unwrap()
                 .unwrap();
             let n = value_t_or_exit!(arg_matches, "n", usize);
-            let ui_amount = value_t_or_exit!(arg_matches, "amount", f64);
+            let ui_amount = *arg_matches.get_one::<Amount>("amount").unwrap();
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", wallet_manager);
             signers.push(owner_signer);
@@ -73,7 +73,7 @@ pub(crate) async fn bench_process_command(
                 .unwrap()
                 .unwrap();
             let n = value_t_or_exit!(arg_matches, "n", usize);
-            let ui_amount = value_t_or_exit!(arg_matches, "amount", f64);
+            let ui_amount = *arg_matches.get_one::<Amount>("amount").unwrap();
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", wallet_manager);
             signers.push(owner_signer);
@@ -237,7 +237,7 @@ async fn command_deposit_into_or_withdraw_from(
     token: &Pubkey,
     n: usize,
     owner: &Pubkey,
-    ui_amount: f64,
+    ui_amount: Amount,
     from_or_to: Option<Pubkey>,
     deposit_into: bool,
 ) -> Result<(), Error> {
@@ -250,7 +250,17 @@ async fn command_deposit_into_or_withdraw_from(
     let from_or_to = from_or_to
         .unwrap_or_else(|| get_associated_token_address_with_program_id(owner, token, &program_id));
     config.check_account(&from_or_to, Some(*token)).await?;
-    let amount = spl_token::ui_amount_to_amount(ui_amount, mint_info.decimals);
+    let amount = match ui_amount {
+        Amount::Raw(ui_amount) => ui_amount,
+        Amount::Decimal(ui_amount) => spl_token::ui_amount_to_amount(ui_amount, mint_info.decimals),
+        Amount::All => {
+            return Err(
+                "Use of ALL keyword currently not supported for the bench command"
+                    .to_string()
+                    .into(),
+            );
+        }
+    };
 
     let token_addresses_with_seed = get_token_addresses_with_seed(&program_id, token, owner, n);
     let mut messages = vec![];

--- a/token/cli/src/bench.rs
+++ b/token/cli/src/bench.rs
@@ -34,7 +34,7 @@ pub(crate) async fn bench_process_command(
             let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
                 .unwrap()
                 .unwrap();
-            let n = value_t_or_exit!(arg_matches, "n", usize);
+            let n = *arg_matches.get_one::<usize>("n").unwrap();
 
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", wallet_manager);
@@ -46,7 +46,7 @@ pub(crate) async fn bench_process_command(
             let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
                 .unwrap()
                 .unwrap();
-            let n = value_t_or_exit!(arg_matches, "n", usize);
+            let n = *arg_matches.get_one::<usize>("n").unwrap();
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", wallet_manager);
             signers.push(owner_signer);
@@ -57,7 +57,7 @@ pub(crate) async fn bench_process_command(
             let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
                 .unwrap()
                 .unwrap();
-            let n = value_t_or_exit!(arg_matches, "n", usize);
+            let n = *arg_matches.get_one::<usize>("n").unwrap();
             let ui_amount = *arg_matches.get_one::<Amount>("amount").unwrap();
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", wallet_manager);
@@ -72,7 +72,7 @@ pub(crate) async fn bench_process_command(
             let token = pubkey_of_signer(arg_matches, "token", wallet_manager)
                 .unwrap()
                 .unwrap();
-            let n = value_t_or_exit!(arg_matches, "n", usize);
+            let n = *arg_matches.get_one::<usize>("n").unwrap();
             let ui_amount = *arg_matches.get_one::<Amount>("amount").unwrap();
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", wallet_manager);

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -7,9 +7,7 @@ use {
     solana_clap_v3_utils::{
         fee_payer::fee_payer_arg,
         input_parsers::Amount,
-        input_validators::{
-            is_parsable, is_pubkey, is_url_or_moniker, is_valid_pubkey, is_valid_signer,
-        },
+        input_validators::{is_pubkey, is_url_or_moniker, is_valid_pubkey, is_valid_signer},
         memo::memo_arg,
         nonce::*,
         offline::{self, *},
@@ -473,7 +471,7 @@ impl BenchSubCommand for App<'_> {
                         )
                         .arg(
                             Arg::with_name("n")
-                                .validator(is_parsable::<usize>)
+                                .value_parser(clap::value_parser!(usize))
                                 .value_name("N")
                                 .takes_value(true)
                                 .index(2)
@@ -496,7 +494,7 @@ impl BenchSubCommand for App<'_> {
                         )
                         .arg(
                             Arg::with_name("n")
-                                .validator(is_parsable::<usize>)
+                                .value_parser(clap::value_parser!(usize))
                                 .value_name("N")
                                 .takes_value(true)
                                 .index(2)
@@ -519,7 +517,7 @@ impl BenchSubCommand for App<'_> {
                         )
                         .arg(
                             Arg::with_name("n")
-                                .validator(is_parsable::<usize>)
+                                .value_parser(clap::value_parser!(usize))
                                 .value_name("N")
                                 .takes_value(true)
                                 .index(2)
@@ -559,7 +557,7 @@ impl BenchSubCommand for App<'_> {
                         )
                         .arg(
                             Arg::with_name("n")
-                                .validator(is_parsable::<usize>)
+                                .value_parser(clap::value_parser!(usize))
                                 .value_name("N")
                                 .takes_value(true)
                                 .index(2)
@@ -672,7 +670,7 @@ pub fn app<'a>(
                 .takes_value(true)
                 .global(true)
                 .value_name("COMPUTE-UNIT-LIMIT")
-                .validator(is_parsable::<u32>)
+                .value_parser(clap::value_parser!(u32))
                 .help(COMPUTE_UNIT_LIMIT_ARG.help)
         )
         .arg(
@@ -681,7 +679,7 @@ pub fn app<'a>(
                 .takes_value(true)
                 .global(true)
                 .value_name("COMPUTE-UNIT-PRICE")
-                .validator(is_parsable::<u64>)
+                .value_parser(clap::value_parser!(u64))
                 .help(COMPUTE_UNIT_PRICE_ARG.help)
         )
         .bench_subcommand()

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -306,16 +306,12 @@ pub fn mint_address_arg<'a>() -> Arg<'a> {
         .help(MINT_ADDRESS_ARG.help)
 }
 
-fn is_mint_decimals(string: &str) -> Result<(), String> {
-    is_parsable::<u8>(string)
-}
-
 pub fn mint_decimals_arg<'a>() -> Arg<'a> {
     Arg::with_name(MINT_DECIMALS_ARG.name)
         .long(MINT_DECIMALS_ARG.long)
         .takes_value(true)
         .value_name("MINT_DECIMALS")
-        .validator(is_mint_decimals)
+        .value_parser(clap::value_parser!(u8))
         .help(MINT_DECIMALS_ARG.help)
 }
 
@@ -717,7 +713,7 @@ pub fn app<'a>(
                 .arg(
                     Arg::with_name("decimals")
                         .long("decimals")
-                        .validator(is_mint_decimals)
+                        .value_parser(clap::value_parser!(u8))
                         .value_name("DECIMALS")
                         .takes_value(true)
                         .default_value(default_decimals)

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -8,7 +8,7 @@ use {
         fee_payer::fee_payer_arg,
         input_parsers::Amount,
         input_validators::{
-            is_amount, is_parsable, is_pubkey, is_url_or_moniker, is_valid_pubkey, is_valid_signer,
+            is_parsable, is_pubkey, is_url_or_moniker, is_valid_pubkey, is_valid_signer,
         },
         memo::memo_arg,
         nonce::*,
@@ -340,7 +340,7 @@ pub fn transfer_lamports_arg<'a>() -> Arg<'a> {
         .long(TRANSFER_LAMPORTS_ARG.long)
         .takes_value(true)
         .value_name("LAMPORTS")
-        .validator(|s| is_amount(s))
+        .value_parser(clap::value_parser!(u64))
         .help(TRANSFER_LAMPORTS_ARG.help)
 }
 
@@ -528,7 +528,7 @@ impl BenchSubCommand for App<'_> {
                         )
                         .arg(
                             Arg::with_name("amount")
-                                .validator(|s| is_amount(s))
+                                .value_parser(Amount::parse)
                                 .value_name("TOKEN_AMOUNT")
                                 .takes_value(true)
                                 .index(3)
@@ -568,7 +568,7 @@ impl BenchSubCommand for App<'_> {
                         )
                         .arg(
                             Arg::with_name("amount")
-                                .validator(|s| is_amount(s))
+                                .value_parser(Amount::parse)
                                 .value_name("TOKEN_AMOUNT")
                                 .takes_value(true)
                                 .index(3)
@@ -835,7 +835,7 @@ pub fn app<'a>(
                         .number_of_values(1)
                         .conflicts_with("transfer_fee")
                         .requires("transfer_fee_basis_points")
-                        .validator(|s| is_amount(s))
+                        .value_parser(Amount::parse)
                         .help(
                             "Add a UI amount maximum transfer fee to the mint. \
                             The mint authority can set and collect fees"
@@ -1086,7 +1086,7 @@ pub fn app<'a>(
                 )
                 .arg(
                         Arg::with_name("max_size")
-                        .validator(|s| is_amount(s))
+                        .value_parser(clap::value_parser!(u64))
                         .value_name("MAX_SIZE")
                         .takes_value(true)
                         .required(true)
@@ -1132,7 +1132,7 @@ pub fn app<'a>(
                 )
                 .arg(
                         Arg::with_name("new_max_size")
-                        .validator(|s| is_amount(s))
+                        .value_parser(clap::value_parser!(u64))
                         .value_name("NEW_MAX_SIZE")
                         .takes_value(true)
                         .required(true)
@@ -1430,8 +1430,8 @@ pub fn app<'a>(
                 .arg(
                     Arg::with_name("expected_fee")
                         .long("expected-fee")
-                        .validator(|s| is_amount(s))
-                        .value_name("TOKEN_AMOUNT")
+                        .value_parser(Amount::parse)
+                        .value_name("EXPECTED_FEE")
                         .takes_value(true)
                         .help("Expected fee amount collected during the transfer"),
                 )
@@ -1510,7 +1510,7 @@ pub fn app<'a>(
                 )
                 .arg(
                     Arg::with_name("amount")
-                        .validator(|s| is_amount(s))
+                        .value_parser(Amount::parse)
                         .value_name("TOKEN_AMOUNT")
                         .takes_value(true)
                         .index(2)
@@ -1620,7 +1620,7 @@ pub fn app<'a>(
                 .about("Wrap native SOL in a SOL token account")
                 .arg(
                     Arg::with_name("amount")
-                        .validator(|s| is_amount(s))
+                        .value_parser(Amount::parse)
                         .value_name("AMOUNT")
                         .takes_value(true)
                         .index(1)
@@ -1702,7 +1702,7 @@ pub fn app<'a>(
                 )
                 .arg(
                     Arg::with_name("amount")
-                        .validator(|s| is_amount(s))
+                        .value_parser(Amount::parse)
                         .value_name("TOKEN_AMOUNT")
                         .takes_value(true)
                         .index(2)
@@ -2333,8 +2333,8 @@ pub fn app<'a>(
                 )
                 .arg(
                     Arg::with_name("maximum_fee")
-                        .value_name("TOKEN_AMOUNT")
-                        .validator(|s| is_amount(s))
+                        .value_name("MAXIMUM_FEE")
+                        .value_parser(Amount::parse)
                         .takes_value(true)
                         .required(true)
                         .help("The new maximum transfer fee in UI amount"),

--- a/token/cli/src/clap_app.rs
+++ b/token/cli/src/clap_app.rs
@@ -6,9 +6,9 @@ use {
     },
     solana_clap_v3_utils::{
         fee_payer::fee_payer_arg,
+        input_parsers::Amount,
         input_validators::{
-            is_amount, is_amount_or_all, is_parsable, is_pubkey, is_url_or_moniker,
-            is_valid_pubkey, is_valid_signer,
+            is_amount, is_parsable, is_pubkey, is_url_or_moniker, is_valid_pubkey, is_valid_signer,
         },
         memo::memo_arg,
         nonce::*,
@@ -1346,7 +1346,7 @@ pub fn app<'a>(
                 )
                 .arg(
                     Arg::with_name("amount")
-                        .validator(|s| is_amount_or_all(s))
+                        .value_parser(Amount::parse)
                         .value_name("TOKEN_AMOUNT")
                         .takes_value(true)
                         .index(2)
@@ -1476,7 +1476,7 @@ pub fn app<'a>(
                 )
                 .arg(
                     Arg::with_name("amount")
-                        .validator(|s| is_amount_or_all(s))
+                        .value_parser(Amount::parse)
                         .value_name("TOKEN_AMOUNT")
                         .takes_value(true)
                         .index(2)
@@ -2602,7 +2602,7 @@ pub fn app<'a>(
                 )
                 .arg(
                     Arg::with_name("amount")
-                        .validator(|s| is_amount_or_all(s))
+                        .value_parser(Amount::parse)
                         .value_name("TOKEN_AMOUNT")
                         .takes_value(true)
                         .index(2)
@@ -2639,7 +2639,7 @@ pub fn app<'a>(
                 )
                 .arg(
                     Arg::with_name("amount")
-                        .validator(|s| is_amount_or_all(s))
+                        .value_parser(Amount::parse)
                         .value_name("TOKEN_AMOUNT")
                         .takes_value(true)
                         .index(2)

--- a/token/cli/src/command.rs
+++ b/token/cli/src/command.rs
@@ -3510,7 +3510,7 @@ pub async fn process_command<'a>(
             .await
         }
         (CommandName::CreateToken, arg_matches) => {
-            let decimals = value_t_or_exit!(arg_matches, "decimals", u8);
+            let decimals = *arg_matches.get_one::<u8>("decimals").unwrap();
             let mint_authority =
                 config.pubkey_or_default(arg_matches, "mint_authority", &mut wallet_manager)?;
             let memo = value_t!(arg_matches, "memo", String).ok();
@@ -3859,9 +3859,7 @@ pub async fn process_command<'a>(
                 push_signer_with_dedup(owner_signer, &mut bulk_signers);
             }
 
-            let mint_decimals = arg_matches
-                .get_one(MINT_DECIMALS_ARG.name)
-                .map(|v: &String| v.parse::<u8>().unwrap());
+            let mint_decimals = arg_matches.get_one::<u8>(MINT_DECIMALS_ARG.name).copied();
             let fund_recipient = arg_matches.is_present("fund_recipient");
             let allow_unfunded_recipient = arg_matches.is_present("allow_empty_recipient")
                 || arg_matches.is_present("allow_unfunded_recipient");
@@ -3948,9 +3946,7 @@ pub async fn process_command<'a>(
                 .unwrap()
                 .unwrap();
             let amount = value_t_or_exit!(arg_matches, "amount", f64);
-            let mint_decimals = arg_matches
-                .get_one(MINT_DECIMALS_ARG.name)
-                .map(|v: &String| v.parse::<u8>().unwrap());
+            let mint_decimals = arg_matches.get_one::<u8>(MINT_DECIMALS_ARG.name).copied();
             let mint_info = config.get_mint_info(&token, mint_decimals).await?;
             let recipient = if let Some(address) =
                 pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager).unwrap()
@@ -4414,9 +4410,7 @@ pub async fn process_command<'a>(
             let maximum_fee = value_t_or_exit!(arg_matches, "maximum_fee", f64);
             let (transfer_fee_authority_signer, transfer_fee_authority_pubkey) = config
                 .signer_or_default(arg_matches, "transfer_fee_authority", &mut wallet_manager);
-            let mint_decimals = arg_matches
-                .get_one(MINT_DECIMALS_ARG.name)
-                .map(|v: &String| v.parse::<u8>().unwrap());
+            let mint_decimals = arg_matches.get_one::<u8>(MINT_DECIMALS_ARG.name).copied();
             let bulk_signers = vec![transfer_fee_authority_signer];
 
             command_set_transfer_fee(
@@ -4561,10 +4555,7 @@ pub async fn process_command<'a>(
 
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
-
-            let mint_decimals = arg_matches
-                .get_one(MINT_DECIMALS_ARG.name)
-                .map(|v: &String| v.parse::<u8>().unwrap());
+            let mint_decimals = arg_matches.get_one::<u8>(MINT_DECIMALS_ARG.name).copied();
 
             let (instruction_type, elgamal_keypair, aes_key) = match c {
                 CommandName::DepositConfidentialTokens => {

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -327,16 +327,10 @@ impl<'a> Config<'a> {
             .flatten()
             .copied();
 
-        let compute_unit_price = matches
-            .try_get_one::<u64>(COMPUTE_UNIT_PRICE_ARG.name)
-            .ok()
-            .flatten()
-            .copied();
+        let compute_unit_price = matches.get_one::<u64>(COMPUTE_UNIT_PRICE_ARG.name).copied();
 
         let compute_unit_limit = matches
-            .try_get_one::<u32>(COMPUTE_UNIT_LIMIT_ARG.name)
-            .ok()
-            .flatten()
+            .get_one::<u32>(COMPUTE_UNIT_LIMIT_ARG.name)
             .copied()
             .map(ComputeUnitLimit::Static)
             .unwrap_or_else(|| {


### PR DESCRIPTION
#### Problem
The token-cli now uses clap-v3, but there are still some deprecated functions that should be removed (we ultimately want to remove `#![allow(deprecated)]` at the top of `clap_app.rs`). In particular, with clap-v3, input validation has been deprecated in favor of just parsing the inputs.

All of the occurrences of `Arg::validator` in the token-cli should be replaced with `Arg::value_parser`. Since there are many of these occurrences, I think these can be removed in a sequence of smaller PRs.

#### Summary of Changes
In this PR, I started removing validator functions related to numbers and amounts. I think the changes should be pretty straightforward:

[318244b](https://github.com/solana-labs/solana-program-library/pull/7448/commits/318244b40ac51450caaec6f227707757dde8e6c7): I started with removing validator `is_mint_decimals` from the clap app and replacing it with the clap builtin parser `clap::value_parser!(u8)` instead. When actually parsing the inputs, we either used the deprecated `value_t_or_exit` or parsed the input as a string and converted it to `u8`. I now updated it to directly use `get_one::<u8>("decimals")` instead.

[eff3494](https://github.com/solana-labs/solana-program-library/pull/7448/commits/eff349483c67f3ef150173fb8b48661b97935ab6): For arguments related to token `amount`, we used the `is_amount_or_all` validator that checks whether it is an unsigned integer (`u64`), decimals (`f64`), or the `All` keyword. In clap-v3, the `Amount` [type](https://github.com/anza-xyz/agave/blob/master/clap-v3-utils/src/input_parsers/mod.rs#L142) was added to parse these type of arguments, so I used `Amount::parse` to replace `is_amount_or_all`. When actually parsing the inputs, I had to use match statements, which makes things a little bit more verbose, but I think the code itself should be a lot more readable.

[06b0c1f](https://github.com/solana-labs/solana-program-library/pull/7448/commits/06b0c1f31174bbc2c78f501999edbe0220c70462): For the arguments, we use the `is_amount` validator function as well, which can either be an unsigned integer (`u64`) or decimals (`f64`) (but not `All` keyword). I replaced these with either `Amount::parse` or `clap::value_parser!(u64)` whichever made sense. In the process, I noticed that we had some inconsistency in the way we name the argument for maximum fee. We sometimes use `MAXIMUM_FEE` and sometimes use `TOKEN_AMOUNT`. I ended up fixing this to all use `MAXIMUM_FEE` instead for consistency. This renaming should just be a cosmetic change.

[ac50d8f](https://github.com/solana-labs/solana-program-library/pull/7448/commits/ac50d8f215396ce9e7d6fb6e163d0c1b9c2bd334): Finally, there were occurrences of validator `is_parsable::<TYPE>`. I replaced these with direct clap parsers `clap::value_parser!(TYPE)`.

There are other validator functions like `is_valid_signer` and `is_valid_pubkey` that we use throughout the code. These will be removed in follow-up PRs.