### PR TITLE
[token-cli] Parse compute unit limit with the proper name

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -334,7 +334,7 @@ impl<'a> Config<'a> {
             .copied();
 
         let compute_unit_limit = matches
-            .try_get_one::<u32>(COMPUTE_UNIT_PRICE_ARG.name)
+            .try_get_one::<u32>(COMPUTE_UNIT_LIMIT_ARG.name)
             .ok()
             .flatten()
             .copied()


### PR DESCRIPTION
#### Problem
It seems that we define `compute_unit_limit` argument in the clap app, but try to parse it as `compute_unit_price`.

#### Summary of Changes
Parse `compute_unit_limit` properly.