### PR TITLE
[token22] Avoid the use of `extend_from_slice` when appending instructions

### DIFF
--- a/token/program-2022/src/extension/confidential_mint_burn/instruction.rs
+++ b/token/program-2022/src/extension/confidential_mint_burn/instruction.rs
@@ -337,7 +337,7 @@ pub fn rotate_supply_elgamal_pubkey(
         },
     )];
 
-    instructions.extend_from_slice(&proof_instructions);
+    instructions.extend(proof_instructions);
 
     Ok(instructions)
 }
@@ -461,7 +461,7 @@ pub fn confidential_mint_with_split_proofs(
         },
     )];
 
-    instructions.extend_from_slice(&proof_instructions);
+    instructions.extend(proof_instructions);
 
     Ok(instructions)
 }
@@ -543,7 +543,7 @@ pub fn confidential_burn_with_split_proofs(
         },
     )];
 
-    instructions.extend_from_slice(&proof_instructions);
+    instructions.extend(proof_instructions);
 
     Ok(instructions)
 }


### PR DESCRIPTION
#### Problem
In the confidential mint and burn extension, the vector of proof instructions are appended to the token instruction using the `extend_from_slice` method, which requires the underlying element type of the slice to implement the `Clone` trait. Though minimal, it is better to use the `extend` function that subsumes the input vector since `extend` does not require the underlying element type to be implement any trait.

This is relevant when building the token22 program for wasm target. The `Instruction` type implements `Clone` for non-wasm targets, but does not seem to implement it for wasm targets (https://github.com/anza-xyz/agave/blob/master/sdk/instruction/src/lib.rs#L108). 

#### Summary of Changes
Replace `extend_from_slice` with `extend`.