### PR TITLE
token: Fix typos for cargo-spellcheck

### DIFF
--- a/token/cli/README.md
+++ b/token/cli/README.md
@@ -1,6 +1,6 @@
 # SPL Token program command-line utility
 
-A basic command-line for creating and using SPL Tokens.  See https://spl.solana.com/token for more details
+A basic command-line for creating and using SPL Tokens.  See <https://spl.solana.com/token> for more details
 
 ## Build
 

--- a/token/cli/src/encryption_keypair.rs
+++ b/token/cli/src/encryption_keypair.rs
@@ -1,6 +1,6 @@
 //! Temporary ElGamal keypair argument parser.
 //!
-//! NOTE: this module should be remoeved in the next Solana upgrade.
+//! NOTE: this module should be removed in the next Solana upgrade.
 
 use {
     base64::{prelude::BASE64_STANDARD, Engine},

--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -901,7 +901,7 @@ where
         mint_result
     }
 
-    /// Retrive mint information.
+    /// Retrieve mint information.
     pub async fn get_mint_info(&self) -> TokenResult<StateWithExtensionsOwned<Mint>> {
         let account = self.get_account(self.pubkey).await?;
         self.unpack_mint_info(account)
@@ -1669,7 +1669,7 @@ where
     }
 
     /// Reallocate a token account to be large enough for a set of
-    /// ExtensionTypes
+    /// `ExtensionType`s
     pub async fn reallocate<S: Signers>(
         &self,
         account: &Pubkey,

--- a/token/confidential-transfer/ciphertext-arithmetic/src/lib.rs
+++ b/token/confidential-transfer/ciphertext-arithmetic/src/lib.rs
@@ -119,7 +119,7 @@ pub fn subtract_from(
     Some(ristretto_to_elgamal_ciphertext(&result_commitment, &handle))
 }
 
-/// Convert a `u64` amount into a curve25519 scalar
+/// Convert a `u64` amount into a curve-25519 scalar
 fn u64_to_scalar(amount: u64) -> PodScalar {
     let mut amount_bytes = [0u8; 32];
     amount_bytes[..8].copy_from_slice(&amount.to_le_bytes());
@@ -141,7 +141,7 @@ fn elgamal_ciphertext_to_ristretto(
 }
 
 /// Convert a pair of `PodRistrettoPoint` to a `PodElGamalCiphertext`
-/// interpretting the first as the commitment and the second as the handle
+/// interpreting the first as the commitment and the second as the handle
 fn ristretto_to_elgamal_ciphertext(
     commitment: &PodRistrettoPoint,
     handle: &PodRistrettoPoint,

--- a/token/confidential-transfer/proof-extraction/src/instruction.rs
+++ b/token/confidential-transfer/proof-extraction/src/instruction.rs
@@ -34,7 +34,7 @@ pub fn check_zk_elgamal_proof_program_account(
 }
 
 /// If a proof is to be read from a record account, the proof instruction data
-/// must be 5 bytes: 1 byte for the proof type and 4 bytes for the u32 offset
+/// must be 5 bytes: 1 byte for the proof type and 4 bytes for the `u32` offset
 const INSTRUCTION_DATA_LENGTH_WITH_RECORD_ACCOUNT: usize = 5;
 
 /// Decodes the proof context data associated with a zero-knowledge proof

--- a/token/confidential-transfer/proof-extraction/src/transfer.rs
+++ b/token/confidential-transfer/proof-extraction/src/transfer.rs
@@ -21,9 +21,9 @@ pub struct TransferPubkeys {
 
 /// The proof context information needed to process a [Transfer] instruction.
 pub struct TransferProofContext {
-    /// Ciphertext containing the low 16 bits of the transafer amount
+    /// Ciphertext containing the low 16 bits of the transfer amount
     pub ciphertext_lo: PodTransferAmountCiphertext,
-    /// Ciphertext containing the high 32 bits of the transafer amount
+    /// Ciphertext containing the high 32 bits of the transfer amount
     pub ciphertext_hi: PodTransferAmountCiphertext,
     /// The transfer public keys associated with a transfer
     pub transfer_pubkeys: TransferPubkeys,

--- a/token/confidential-transfer/proof-extraction/src/transfer_with_fee.rs
+++ b/token/confidential-transfer/proof-extraction/src/transfer_with_fee.rs
@@ -48,8 +48,8 @@ pub struct TransferWithFeeProofContext {
     pub ciphertext_lo: PodTransferAmountCiphertext,
     /// Group encryption of the high 48 bits of the transfer amount
     pub ciphertext_hi: PodTransferAmountCiphertext,
-    /// The public encryption keys associated with the transfer: source, dest,
-    /// auditor, and withdraw withheld authority
+    /// The public encryption keys associated with the transfer: source,
+    /// destination, auditor, and withdraw withheld authority
     pub transfer_with_fee_pubkeys: TransferWithFeePubkeys,
     /// The final spendable ciphertext after the transfer,
     pub new_source_ciphertext: PodElGamalCiphertext,
@@ -250,20 +250,20 @@ impl TransferWithFeeProofContext {
     }
 }
 
-/// Ristretto generator point for curve25519
+/// Ristretto generator point for curve-25519
 const G: PodRistrettoPoint = PodRistrettoPoint([
     226, 242, 174, 10, 106, 188, 78, 113, 168, 132, 169, 97, 197, 0, 81, 95, 88, 227, 11, 106, 165,
     130, 221, 141, 182, 166, 89, 69, 224, 141, 45, 118,
 ]);
 
-/// Convert a `u64` amount into a curve25519 scalar
+/// Convert a `u64` amount into a curve-25519 scalar
 fn u64_to_scalar(amount: u64) -> PodScalar {
     let mut bytes = [0u8; 32];
     bytes[..8].copy_from_slice(&amount.to_le_bytes());
     PodScalar(bytes)
 }
 
-/// Convert a `u16` amount into a curve25519 scalar
+/// Convert a `u16` amount into a curve-25519 scalar
 fn u16_to_scalar(amount: u16) -> PodScalar {
     let mut bytes = [0u8; 32];
     bytes[..2].copy_from_slice(&amount.to_le_bytes());

--- a/token/confidential-transfer/proof-generation/src/lib.rs
+++ b/token/confidential-transfer/proof-generation/src/lib.rs
@@ -26,8 +26,8 @@ pub const TRANSFER_AMOUNT_HI_BITS: usize = 32;
 pub const REMAINING_BALANCE_BIT_LENGTH: usize = 64;
 
 /// Takes in a 64-bit number `amount` and a bit length `bit_length`. It returns:
-/// - the `bit_length` low bits of `amount` interpretted as u64
-/// - the `(64 - bit_length)` high bits of `amount` interpretted as u64
+/// - the `bit_length` low bits of `amount` interpreted as `u64`
+/// - the `(64 - bit_length)` high bits of `amount` interpreted as `u64`
 pub fn try_split_u64(amount: u64, bit_length: usize) -> Option<(u64, u64)> {
     match bit_length {
         0 => Some((0, amount)),
@@ -45,7 +45,7 @@ pub fn try_split_u64(amount: u64, bit_length: usize) -> Option<(u64, u64)> {
     }
 }
 
-/// Combine two numbers that are interpretted as the low and high bits of a
+/// Combine two numbers that are interpreted as the low and high bits of a
 /// target number. The `bit_length` parameter specifies the number of bits that
 /// `amount_hi` is to be shifted by.
 pub fn try_combine_lo_hi_u64(amount_lo: u64, amount_hi: u64, bit_length: usize) -> Option<u64> {

--- a/token/program-2022/src/extension/confidential_mint_burn/account_info.rs
+++ b/token/program-2022/src/extension/confidential_mint_burn/account_info.rs
@@ -25,13 +25,13 @@ pub struct SupplyAccountInfo {
     pub current_supply: PodElGamalCiphertext,
     /// The decryptable supply
     pub decryptable_supply: PodAeCiphertext,
-    /// The supply's elgamal pubkey
+    /// The supply's ElGamal pubkey
     pub supply_elgamal_pubkey: PodElGamalPubkey,
 }
 
 impl SupplyAccountInfo {
-    /// Creates a SupplyAccountInfo from ConfidentialMintBurn extension account
-    /// data
+    /// Creates a `SupplyAccountInfo` from `ConfidentialMintBurn` extension
+    /// account data
     pub fn new(extension: &ConfidentialMintBurn) -> Self {
         Self {
             current_supply: extension.confidential_supply,
@@ -41,7 +41,7 @@ impl SupplyAccountInfo {
     }
 
     /// Computes the current supply from the decryptable supply and the
-    /// difference between the decryptable supply and the elgamal encrypted
+    /// difference between the decryptable supply and the ElGamal encrypted
     /// supply ciphertext
     pub fn decrypt_current_supply(
         &self,

--- a/token/program-2022/src/extension/confidential_mint_burn/instruction.rs
+++ b/token/program-2022/src/extension/confidential_mint_burn/instruction.rs
@@ -194,7 +194,7 @@ pub struct InitializeMintData {
     /// The ElGamal pubkey used to encrypt the confidential supply
     #[cfg_attr(feature = "serde-traits", serde(with = "elgamalpubkey_fromstr"))]
     pub supply_elgamal_pubkey: PodElGamalPubkey,
-    /// The initial 0 supply ecrypted with the supply aes key
+    /// The initial 0 supply encrypted with the supply aes key
     #[cfg_attr(feature = "serde-traits", serde(with = "aeciphertext_fromstr"))]
     pub decryptable_supply: PodAeCiphertext,
 }

--- a/token/program-2022/src/extension/confidential_mint_burn/mod.rs
+++ b/token/program-2022/src/extension/confidential_mint_burn/mod.rs
@@ -9,7 +9,7 @@ use {
 
 /// Maximum bit length of any mint or burn amount
 ///
-/// Any mint or burn amount must be less than 2^48
+/// Any mint or burn amount must be less than `2^48`
 pub const MAXIMUM_DEPOSIT_TRANSFER_AMOUNT: u64 = (u16::MAX as u64) + (1 << 16) * (u32::MAX as u64);
 
 /// Bit length of the low bits of pending balance plaintext

--- a/token/program-2022/src/extension/confidential_mint_burn/processor.rs
+++ b/token/program-2022/src/extension/confidential_mint_burn/processor.rs
@@ -37,7 +37,7 @@ use {
     spl_token_confidential_transfer_proof_extraction::instruction::verify_and_extract_context,
 };
 
-/// Processes an [InitializeMint] instruction.
+/// Processes an [`InitializeMint`] instruction.
 fn process_initialize_mint(accounts: &[AccountInfo], data: &InitializeMintData) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;
@@ -54,7 +54,7 @@ fn process_initialize_mint(accounts: &[AccountInfo], data: &InitializeMintData) 
     Ok(())
 }
 
-/// Processes an [RotateSupplyElGamal] instruction.
+/// Processes an [`RotateSupplyElGamal`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_rotate_supply_elgamal_pubkey(
     program_id: &Pubkey,
@@ -110,7 +110,7 @@ fn process_rotate_supply_elgamal_pubkey(
     Ok(())
 }
 
-/// Processes an [UpdateAuthority] instruction.
+/// Processes an [`UpdateAuthority`] instruction.
 fn process_update_decryptable_supply(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -142,7 +142,7 @@ fn process_update_decryptable_supply(
     Ok(())
 }
 
-/// Processes a [ConfidentialMint] instruction.
+/// Processes a [`ConfidentialMint`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_confidential_mint(
     program_id: &Pubkey,
@@ -267,7 +267,7 @@ fn process_confidential_mint(
     Ok(())
 }
 
-/// Processes a [ConfidentialBurn] instruction.
+/// Processes a [`ConfidentialBurn`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_confidential_burn(
     program_id: &Pubkey,

--- a/token/program-2022/src/extension/confidential_mint_burn/verify_proof.rs
+++ b/token/program-2022/src/extension/confidential_mint_burn/verify_proof.rs
@@ -17,8 +17,8 @@ use {
     std::slice::Iter,
 };
 
-/// Verify zero-knowledge proofs needed for a [ConfidentialMint] instruction and
-/// return the corresponding proof context information.
+/// Verify zero-knowledge proofs needed for a [`ConfidentialMint`] instruction
+/// and return the corresponding proof context information.
 #[cfg(feature = "zk-ops")]
 pub fn verify_mint_proof(
     account_info_iter: &mut Iter<'_, AccountInfo<'_>>,
@@ -65,8 +65,8 @@ pub fn verify_mint_proof(
     .map_err(|e| -> TokenError { e.into() })?)
 }
 
-/// Verify zero-knowledge proofs needed for a [ConfidentialBurn] instruction and
-/// return the corresponding proof context information.
+/// Verify zero-knowledge proofs needed for a [`ConfidentialBurn`] instruction
+/// and return the corresponding proof context information.
 #[cfg(feature = "zk-ops")]
 pub fn verify_burn_proof(
     account_info_iter: &mut Iter<'_, AccountInfo<'_>>,

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -494,7 +494,7 @@ pub enum ConfidentialTransferInstruction {
     /// validity proof as well as the token owner signature.
     ///
     /// If the token account is not large enough to include the new
-    /// cconfidential transfer extension, then optionally reallocate the
+    /// confidential transfer extension, then optionally reallocate the
     /// account to increase the data size. To reallocate, a payer account to
     /// fund the reallocation and the system account should be included in the
     /// instruction.

--- a/token/program-2022/src/extension/confidential_transfer/mod.rs
+++ b/token/program-2022/src/extension/confidential_transfer/mod.rs
@@ -17,7 +17,7 @@ use {
 
 /// Maximum bit length of any deposit or transfer amount
 ///
-/// Any deposit or transfer amount must be less than 2^48
+/// Any deposit or transfer amount must be less than `2^48`
 pub const MAXIMUM_DEPOSIT_TRANSFER_AMOUNT: u64 = (u16::MAX as u64) + (1 << 16) * (u32::MAX as u64);
 
 /// Bit length of the low bits of pending balance plaintext
@@ -64,7 +64,7 @@ pub struct ConfidentialTransferMint {
     ///   `ConfidentialTransferInstruction::ConfigureAccount`)
     pub auto_approve_new_accounts: PodBool,
 
-    /// Authority to decode any transfer amount in a confidential transafer.
+    /// Authority to decode any transfer amount in a confidential transfer.
     pub auditor_elgamal_pubkey: OptionalNonZeroElGamalPubkey,
 }
 

--- a/token/program-2022/src/extension/confidential_transfer/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer/processor.rs
@@ -45,7 +45,7 @@ use {
     },
 };
 
-/// Processes an [InitializeMint] instruction.
+/// Processes an [`InitializeMint`] instruction.
 fn process_initialize_mint(
     accounts: &[AccountInfo],
     authority: &OptionalNonZeroPubkey,
@@ -67,7 +67,7 @@ fn process_initialize_mint(
     Ok(())
 }
 
-/// Processes an [UpdateMint] instruction.
+/// Processes an [`UpdateMint`] instruction.
 fn process_update_mint(
     accounts: &[AccountInfo],
     auto_approve_new_account: PodBool,
@@ -104,7 +104,7 @@ enum ElGamalPubkeySource<'a> {
     ElGamalRegistry(&'a ElGamalRegistry),
 }
 
-/// Processes a [ConfigureAccountWithRegistry] instruction.
+/// Processes a [`ConfigureAccountWithRegistry`] instruction.
 fn process_configure_account_with_registry(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -195,7 +195,7 @@ fn reallocate_for_configure_account_with_registry<'a>(
     Ok(())
 }
 
-/// Processes a [ConfigureAccount] instruction.
+/// Processes a [`ConfigureAccount`] instruction.
 fn process_configure_account(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -292,7 +292,7 @@ fn process_configure_account(
     Ok(())
 }
 
-/// Processes an [ApproveAccount] instruction.
+/// Processes an [`ApproveAccount`] instruction.
 fn process_approve_account(accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let token_account_info = next_account_info(account_info_iter)?;
@@ -326,7 +326,7 @@ fn process_approve_account(accounts: &[AccountInfo]) -> ProgramResult {
     }
 }
 
-/// Processes an [EmptyAccount] instruction.
+/// Processes an [`EmptyAccount`] instruction.
 fn process_empty_account(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -379,7 +379,7 @@ fn process_empty_account(
     Ok(())
 }
 
-/// Processes a [Deposit] instruction.
+/// Processes a [`Deposit`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_deposit(
     program_id: &Pubkey,
@@ -480,7 +480,7 @@ pub fn verify_and_split_deposit_amount(amount: u64) -> Result<(u64, u64), TokenE
     Ok((deposit_amount_lo, deposit_amount_hi))
 }
 
-/// Processes a [Withdraw] instruction.
+/// Processes a [`Withdraw`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_withdraw(
     program_id: &Pubkey,
@@ -584,7 +584,7 @@ fn process_withdraw(
     Ok(())
 }
 
-/// Processes a [Transfer] or [TransferWithFee] instruction.
+/// Processes a [`Transfer`] or [`TransferWithFee`] instruction.
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "zk-ops")]
 fn process_transfer(
@@ -1127,7 +1127,7 @@ fn process_destination_for_transfer_with_fee(
     Ok(())
 }
 
-/// Processes an [ApplyPendingBalance] instruction.
+/// Processes an [`ApplyPendingBalance`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_apply_pending_balance(
     program_id: &Pubkey,
@@ -1177,7 +1177,7 @@ fn process_apply_pending_balance(
     Ok(())
 }
 
-/// Processes a [DisableConfidentialCredits] or [EnableConfidentialCredits]
+/// Processes a [`DisableConfidentialCredits`] or [`EnableConfidentialCredits`]
 /// instruction.
 fn process_allow_confidential_credits(
     program_id: &Pubkey,
@@ -1208,8 +1208,8 @@ fn process_allow_confidential_credits(
     Ok(())
 }
 
-/// Processes an [DisableNonConfidentialCredits] or
-/// [EnableNonConfidentialCredits] instruction.
+/// Processes an [`DisableNonConfidentialCredits`] or
+/// [`EnableNonConfidentialCredits`] instruction.
 fn process_allow_non_confidential_credits(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs
@@ -91,10 +91,10 @@ pub enum ConfidentialTransferFeeInstruction {
     ///   3. `[]` (Optional) Record account if the accompanying proof is to be
     ///      read from a record account.
     ///   4. `[]` The mint's multisig `withdraw_withheld_authority`.
-    ///   5. ..5+M `[signer]` M signer accounts.
+    ///   5. ..`5+M` `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
-    ///   WithdrawWithheldTokensFromMintData
+    ///   `WithdrawWithheldTokensFromMintData`
     WithdrawWithheldTokensFromMint,
 
     /// Transfer all withheld tokens to an account. Signed by the mint's
@@ -143,7 +143,7 @@ pub enum ConfidentialTransferFeeInstruction {
     ///   3. `[]` (Optional) Record account if the accompanying proof is to be
     ///      read from a record account.
     ///   4. `[signer]` The mint's `withdraw_withheld_authority`.
-    ///   5. ..3+N `[writable]` The source accounts to withdraw from.
+    ///   5. ..`5+N` `[writable]` The source accounts to withdraw from.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[]` The token mint. Must include the `TransferFeeConfig`
@@ -157,11 +157,11 @@ pub enum ConfidentialTransferFeeInstruction {
     ///   3. `[]` (Optional) Record account if the accompanying proof is to be
     ///      read from a record account.
     ///   4. `[]` The mint's multisig `withdraw_withheld_authority`.
-    ///   5. ..5+M `[signer]` M signer accounts.
-    ///   6. 5+M+1..5+M+N `[writable]` The source accounts to withdraw from.
+    ///   5. ..`5+M` `[signer]` M signer accounts.
+    ///   6. `5+M+1..5+M+N` `[writable]` The source accounts to withdraw from.
     ///
     /// Data expected by this instruction:
-    ///   WithdrawWithheldTokensFromAccountsData
+    ///   `WithdrawWithheldTokensFromAccountsData`
     WithdrawWithheldTokensFromAccounts,
 
     /// Permissionless instruction to transfer all withheld confidential tokens
@@ -175,7 +175,7 @@ pub enum ConfidentialTransferFeeInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint.
-    ///   1. ..1+N `[writable]` The source accounts to harvest from.
+    ///   1. ..`1+N` `[writable]` The source accounts to harvest from.
     ///
     /// Data expected by this instruction:
     ///   None

--- a/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
+++ b/token/program-2022/src/extension/confidential_transfer_fee/processor.rs
@@ -41,7 +41,7 @@ use {
     spl_token_confidential_transfer_proof_extraction::instruction::verify_and_extract_context,
 };
 
-/// Processes an [InitializeConfidentialTransferFeeConfig] instruction.
+/// Processes an [`InitializeConfidentialTransferFeeConfig`] instruction.
 fn process_initialize_confidential_transfer_fee_config(
     accounts: &[AccountInfo],
     authority: &OptionalNonZeroPubkey,
@@ -62,7 +62,7 @@ fn process_initialize_confidential_transfer_fee_config(
     Ok(())
 }
 
-/// Processes a [WithdrawWithheldTokensFromMint] instruction.
+/// Processes a [`WithdrawWithheldTokensFromMint`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_withdraw_withheld_tokens_from_mint(
     program_id: &Pubkey,
@@ -167,7 +167,7 @@ fn process_withdraw_withheld_tokens_from_mint(
     Ok(())
 }
 
-/// Processes a [WithdrawWithheldTokensFromAccounts] instruction.
+/// Processes a [`WithdrawWithheldTokensFromAccounts`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_withdraw_withheld_tokens_from_accounts(
     program_id: &Pubkey,
@@ -322,7 +322,7 @@ fn harvest_from_account<'b>(
     Ok(withheld_amount)
 }
 
-/// Process a [HarvestWithheldTokensToMint] instruction.
+/// Process a [`HarvestWithheldTokensToMint`] instruction.
 #[cfg(feature = "zk-ops")]
 fn process_harvest_withheld_tokens_to_mint(accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -361,7 +361,7 @@ fn process_harvest_withheld_tokens_to_mint(accounts: &[AccountInfo]) -> ProgramR
     Ok(())
 }
 
-/// Process a [EnableHarvestToMint] instruction.
+/// Process a [`EnableHarvestToMint`] instruction.
 fn process_enable_harvest_to_mint(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;
@@ -391,7 +391,7 @@ fn process_enable_harvest_to_mint(program_id: &Pubkey, accounts: &[AccountInfo])
     Ok(())
 }
 
-/// Process a [DisableHarvestToMint] instruction.
+/// Process a [`DisableHarvestToMint`] instruction.
 fn process_disable_harvest_to_mint(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let mint_info = next_account_info(account_info_iter)?;

--- a/token/program-2022/src/extension/cpi_guard/instruction.rs
+++ b/token/program-2022/src/extension/cpi_guard/instruction.rs
@@ -21,10 +21,10 @@ use {
 pub enum CpiGuardInstruction {
     /// Lock certain token operations from taking place within CPI for this
     /// Account, namely:
-    /// * Transfer and Burn must go through a delegate.
-    /// * CloseAccount can only return lamports to owner.
-    /// * SetAuthority can only be used to remove an existing close authority.
-    /// * Approve is disallowed entirely.
+    /// * `Transfer` and `Burn` must go through a delegate.
+    /// * `CloseAccount` can only return lamports to owner.
+    /// * `SetAuthority` can only be used to remove an existing close authority.
+    /// * `Approve` is disallowed entirely.
     ///
     /// In addition, CPI Guard cannot be enabled or disabled via CPI.
     ///
@@ -36,7 +36,7 @@ pub enum CpiGuardInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The account to update.
     ///   1. `[]` The account's multisignature owner.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     Enable,
     /// Allow all token operations to happen via CPI as normal.
     ///
@@ -51,7 +51,7 @@ pub enum CpiGuardInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The account to update.
     ///   1. `[]`  The account's multisignature owner.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     Disable,
 }
 

--- a/token/program-2022/src/extension/cpi_guard/processor.rs
+++ b/token/program-2022/src/extension/cpi_guard/processor.rs
@@ -18,7 +18,7 @@ use {
     },
 };
 
-/// Toggle the CpiGuard extension, initializing the extension if not already
+/// Toggle the `CpiGuard` extension, initializing the extension if not already
 /// present.
 fn process_toggle_cpi_guard(
     program_id: &Pubkey,

--- a/token/program-2022/src/extension/default_account_state/instruction.rs
+++ b/token/program-2022/src/extension/default_account_state/instruction.rs
@@ -48,14 +48,15 @@ pub enum DefaultAccountStateInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's multisignature freeze authority.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
     ///   `crate::state::AccountState`
     Update,
 }
 
-/// Utility function for decoding a DefaultAccountState instruction and its data
+/// Utility function for decoding a `DefaultAccountState` instruction and its
+/// data
 pub fn decode_instruction(
     input: &[u8],
 ) -> Result<(DefaultAccountStateInstruction, AccountState), ProgramError> {

--- a/token/program-2022/src/extension/group_member_pointer/instruction.rs
+++ b/token/program-2022/src/extension/group_member_pointer/instruction.rs
@@ -50,7 +50,7 @@ pub enum GroupMemberPointerInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.
     ///   1. `[]`         The group member pointer authority.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
     ///   `crate::extension::group_member_pointer::instruction::UpdateInstructionData`

--- a/token/program-2022/src/extension/group_member_pointer/mod.rs
+++ b/token/program-2022/src/extension/group_member_pointer/mod.rs
@@ -6,9 +6,9 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
 
-/// Instructions for the GroupMemberPointer extension
+/// Instructions for the `GroupMemberPointer` extension
 pub mod instruction;
-/// Instruction processor for the GroupMemberPointer extension
+/// Instruction processor for the `GroupMemberPointer` extension
 pub mod processor;
 
 /// Group member pointer extension data for mints.

--- a/token/program-2022/src/extension/group_pointer/instruction.rs
+++ b/token/program-2022/src/extension/group_pointer/instruction.rs
@@ -50,7 +50,7 @@ pub enum GroupPointerInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's group pointer authority.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
     ///   `crate::extension::group_pointer::instruction::UpdateInstructionData`

--- a/token/program-2022/src/extension/group_pointer/mod.rs
+++ b/token/program-2022/src/extension/group_pointer/mod.rs
@@ -6,9 +6,9 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
 
-/// Instructions for the GroupPointer extension
+/// Instructions for the `GroupPointer` extension
 pub mod instruction;
-/// Instruction processor for the GroupPointer extension
+/// Instruction processor for the `GroupPointer` extension
 pub mod processor;
 
 /// Group pointer extension data for mints.

--- a/token/program-2022/src/extension/interest_bearing_mint/instruction.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/instruction.rs
@@ -51,7 +51,7 @@ pub enum InterestBearingMintInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's multisignature rate authority.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
     ///   `crate::extension::interest_bearing::BasisPoints`

--- a/token/program-2022/src/extension/interest_bearing_mint/mod.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/mod.rs
@@ -22,7 +22,7 @@ pub type BasisPoints = PodI16;
 const ONE_IN_BASIS_POINTS: f64 = 10_000.;
 const SECONDS_PER_YEAR: f64 = 60. * 60. * 24. * 365.24;
 
-/// UnixTimestamp expressed with an alignment-independent type
+/// `UnixTimestamp` expressed with an alignment-independent type
 pub type UnixTimestamp = PodI64;
 
 /// Interest-bearing extension data for mints
@@ -120,11 +120,13 @@ impl InterestBearingConfig {
     /// The new average rate is the time-weighted average of the current rate
     /// and average rate, solving for r such that:
     ///
+    /// ```no_run
     /// exp(r_1 * t_1) * exp(r_2 * t_2) = exp(r * (t_1 + t_2))
     ///
     /// r_1 * t_1 + r_2 * t_2 = r * (t_1 + t_2)
     ///
     /// r = (r_1 * t_1 + r_2 * t_2) / (t_1 + t_2)
+    /// ```
     pub fn time_weighted_average_rate(&self, current_timestamp: i64) -> Option<i16> {
         let initialization_timestamp = i64::from(self.initialization_timestamp) as i128;
         let last_update_timestamp = i64::from(self.last_update_timestamp) as i128;

--- a/token/program-2022/src/extension/interest_bearing_mint/mod.rs
+++ b/token/program-2022/src/extension/interest_bearing_mint/mod.rs
@@ -120,7 +120,7 @@ impl InterestBearingConfig {
     /// The new average rate is the time-weighted average of the current rate
     /// and average rate, solving for r such that:
     ///
-    /// ```no_run
+    /// ```text
     /// exp(r_1 * t_1) * exp(r_2 * t_2) = exp(r * (t_1 + t_2))
     ///
     /// r_1 * t_1 + r_2 * t_2 = r * (t_1 + t_2)

--- a/token/program-2022/src/extension/memo_transfer/instruction.rs
+++ b/token/program-2022/src/extension/memo_transfer/instruction.rs
@@ -19,7 +19,7 @@ use {
 #[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 pub enum RequiredMemoTransfersInstruction {
-    /// Require memos for transfers into this Account. Adds the MemoTransfer
+    /// Require memos for transfers into this Account. Adds the `MemoTransfer`
     /// extension to the Account, if it doesn't already exist.
     ///
     /// Accounts expected by this instruction:
@@ -30,7 +30,7 @@ pub enum RequiredMemoTransfersInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The account to update.
     ///   1. `[]` The account's multisignature owner.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     Enable,
     /// Stop requiring memos for transfers into this Account.
     ///
@@ -45,7 +45,7 @@ pub enum RequiredMemoTransfersInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The account to update.
     ///   1. `[]`  The account's multisignature owner.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     Disable,
 }
 

--- a/token/program-2022/src/extension/memo_transfer/processor.rs
+++ b/token/program-2022/src/extension/memo_transfer/processor.rs
@@ -17,7 +17,7 @@ use {
     },
 };
 
-/// Toggle the RequiredMemoTransfers extension, initializing the extension if
+/// Toggle the `RequiredMemoTransfers` extension, initializing the extension if
 /// not already present.
 fn process_toggle_required_memo_transfers(
     program_id: &Pubkey,

--- a/token/program-2022/src/extension/metadata_pointer/instruction.rs
+++ b/token/program-2022/src/extension/metadata_pointer/instruction.rs
@@ -50,7 +50,7 @@ pub enum MetadataPointerInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's metadata pointer authority.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
     ///   `crate::extension::metadata_pointer::instruction::UpdateInstructionData`

--- a/token/program-2022/src/extension/metadata_pointer/mod.rs
+++ b/token/program-2022/src/extension/metadata_pointer/mod.rs
@@ -6,9 +6,9 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
 };
 
-/// Instructions for the MetadataPointer extension
+/// Instructions for the `MetadataPointer` extension
 pub mod instruction;
-/// Instruction processor for the MetadataPointer extension
+/// Instruction processor for the `MetadataPointer` extension
 pub mod processor;
 
 /// Metadata pointer extension data for mints.

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -106,7 +106,7 @@ impl TryFrom<usize> for Length {
     }
 }
 
-/// Helper function to get the current TlvIndices from the current spot
+/// Helper function to get the current `TlvIndices` from the current spot
 fn get_tlv_indices(type_start: usize) -> TlvIndices {
     let length_start = type_start.saturating_add(size_of::<ExtensionType>());
     let value_start = length_start.saturating_add(pod_get_packed_len::<Length>());
@@ -280,6 +280,7 @@ fn check_account_type<S: BaseState>(account_type: AccountType) -> Result<(), Pro
 /// Account with an extension, even if we add the account type. For example,
 /// let's say we have:
 ///
+/// ```no_run
 /// Account: 165 bytes... + [2, 0, 3, 0, 100, ....]
 ///                          ^     ^       ^     ^
 ///                     acct type  extension length data...
@@ -287,14 +288,15 @@ fn check_account_type<S: BaseState>(account_type: AccountType) -> Result<(), Pro
 /// Mint: 82 bytes... + 83 bytes of other extension data
 ///     + [2, 0, 3, 0, 100, ....]
 ///      (data in extension just happens to look like this)
+/// ```
 ///
-/// With this approach, we only start writing the TLV data after Account::LEN,
+/// With this approach, we only start writing the TLV data after `Account::LEN`,
 /// which means we always know that the account type is going to be right after
 /// that. We do a special case checking for a Multisig length, because those
 /// aren't extensible under any circumstances.
 const BASE_ACCOUNT_LENGTH: usize = Account::LEN;
-/// Helper that tacks on the AccountType length, which gives the minimum for any
-/// account with extensions
+/// Helper that tacks on the `AccountType` length, which gives the minimum for
+/// any account with extensions
 const BASE_ACCOUNT_AND_TYPE_LENGTH: usize = BASE_ACCOUNT_LENGTH + size_of::<AccountType>();
 
 fn type_and_tlv_indices<S: BaseState>(
@@ -423,7 +425,7 @@ pub trait BaseStateWithExtensions<S: BaseState> {
         get_tlv_data_info(self.get_tlv_data()).map(|x| x.extension_types)
     }
 
-    /// Get just the first extension type, useful to track mixed initializations
+    /// Get just the first extension type, useful to track mixed initialization
     fn get_first_extension_type(&self) -> Result<Option<ExtensionType>, ProgramError> {
         get_first_extension_type(self.get_tlv_data())
     }
@@ -737,12 +739,12 @@ pub trait BaseStateWithExtensionsMut<S: BaseState>: BaseStateWithExtensions<S> {
         }
     }
 
-    /// If `extension_type` is an Account-associated ExtensionType that requires
-    /// initialization on InitializeAccount, this method packs the default
-    /// relevant Extension of an ExtensionType into an open slot if not
-    /// already found in the data buffer, otherwise overwrites the
-    /// existing extension with the default state. For all other ExtensionTypes,
-    /// this is a no-op.
+    /// If `extension_type` is an Account-associated `ExtensionType` that
+    /// requires initialization on `InitializeAccount`, this method packs
+    /// the default relevant `Extension` of an `ExtensionType` into an open
+    /// slot if not already found in the data buffer, otherwise overwrites
+    /// the existing extension with the default state. For all other
+    /// `ExtensionType`s, this is a no-op.
     fn init_account_extension_from_type(
         &mut self,
         extension_type: ExtensionType,
@@ -996,10 +998,10 @@ fn unpack_uninitialized_type_and_tlv_data_mut<S: BaseState>(
     })
 }
 
-/// If AccountType is uninitialized, set it to the BaseState's ACCOUNT_TYPE;
-/// if AccountType is already set, check is set correctly for BaseState
-/// This method assumes that the `base_data` has already been packed with data
-/// of the desired type.
+/// If `AccountType` is uninitialized, set it to the `BaseState`'s
+/// `ACCOUNT_TYPE`; if `AccountType` is already set, check is set correctly for
+/// `BaseState`. This method assumes that the `base_data` has already been
+/// packed with data of the desired type.
 pub fn set_account_type<S: BaseState>(input: &mut [u8]) -> Result<(), ProgramError> {
     check_min_len_and_not_multisig(input, S::SIZE_OF)?;
     let (base_data, rest) = input.split_at_mut(S::SIZE_OF);
@@ -1198,14 +1200,14 @@ impl ExtensionType {
         })
     }
 
-    /// Get the TLV length for an ExtensionType
+    /// Get the TLV length for an `ExtensionType`
     ///
     /// Fails if the extension type has a variable length
     fn try_get_tlv_len(&self) -> Result<usize, ProgramError> {
         Ok(add_type_and_length_to_len(self.try_get_type_len()?))
     }
 
-    /// Get the TLV length for a set of ExtensionTypes
+    /// Get the TLV length for a set of `ExtensionType`s
     ///
     /// Fails if any of the extension types has a variable length
     fn try_get_total_tlv_len(extension_types: &[Self]) -> Result<usize, ProgramError> {
@@ -1219,7 +1221,7 @@ impl ExtensionType {
         extensions.iter().map(|e| e.try_get_tlv_len()).sum()
     }
 
-    /// Get the required account data length for the given ExtensionTypes
+    /// Get the required account data length for the given `ExtensionType`s
     ///
     /// Fails if any of the extension types has a variable length
     pub fn try_calculate_account_len<S: BaseState>(
@@ -1271,8 +1273,8 @@ impl ExtensionType {
         }
     }
 
-    /// Based on a set of AccountType::Mint ExtensionTypes, get the list of
-    /// AccountType::Account ExtensionTypes required on InitializeAccount
+    /// Based on a set of `AccountType::Mint` `ExtensionType`s, get the list of
+    /// `AccountType::Account` `ExtensionType`s required on `InitializeAccount`
     pub fn get_required_init_account_extensions(mint_extension_types: &[Self]) -> Vec<Self> {
         let mut account_extension_types = vec![];
         for extension_type in mint_extension_types {
@@ -1360,10 +1362,14 @@ pub trait Extension {
     const TYPE: ExtensionType;
 }
 
-/// Padding a mint account to be exactly Multisig::LEN.
-/// We need to pad 185 bytes, since Multisig::LEN = 355, Account::LEN = 165,
-/// size_of AccountType = 1, size_of ExtensionType = 2, size_of Length = 2.
+/// Padding a mint account to be exactly `Multisig::LEN`.
+/// We need to pad 185 bytes, since `Multisig::LEN = 355`, `Account::LEN = 165`,
+/// `size_of::<AccountType>() = 1`, `size_of::<ExtensionType>() = 2`,
+/// `size_of::<Length>() = 2`.
+///
+/// ```no_run
 /// 355 - 165 - 1 - 2 - 2 = 185
+/// ```
 #[cfg(test)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
@@ -1389,7 +1395,7 @@ impl Default for MintPaddingTest {
         }
     }
 }
-/// Account version of the MintPadding
+/// Account version of the `MintPadding`
 #[cfg(test)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]

--- a/token/program-2022/src/extension/mod.rs
+++ b/token/program-2022/src/extension/mod.rs
@@ -280,7 +280,7 @@ fn check_account_type<S: BaseState>(account_type: AccountType) -> Result<(), Pro
 /// Account with an extension, even if we add the account type. For example,
 /// let's say we have:
 ///
-/// ```no_run
+/// ```text
 /// Account: 165 bytes... + [2, 0, 3, 0, 100, ....]
 ///                          ^     ^       ^     ^
 ///                     acct type  extension length data...
@@ -1367,8 +1367,8 @@ pub trait Extension {
 /// `size_of::<AccountType>() = 1`, `size_of::<ExtensionType>() = 2`,
 /// `size_of::<Length>() = 2`.
 ///
-/// ```no_run
-/// 355 - 165 - 1 - 2 - 2 = 185
+/// ```
+/// assert_eq!(355 - 165 - 1 - 2 - 2, 185);
 /// ```
 #[cfg(test)]
 #[repr(C)]

--- a/token/program-2022/src/extension/token_group/mod.rs
+++ b/token/program-2022/src/extension/token_group/mod.rs
@@ -3,7 +3,7 @@ use {
     spl_token_group_interface::state::{TokenGroup, TokenGroupMember},
 };
 
-/// Instruction processor for the TokenGroup extensions
+/// Instruction processor for the `TokenGroup` extension
 pub mod processor;
 
 impl Extension for TokenGroup {

--- a/token/program-2022/src/extension/token_group/processor.rs
+++ b/token/program-2022/src/extension/token_group/processor.rs
@@ -43,7 +43,8 @@ fn check_update_authority(
     Ok(())
 }
 
-/// Processes a [InitializeGroup](enum.TokenGroupInstruction.html) instruction.
+/// Processes a [`InitializeGroup`](enum.TokenGroupInstruction.html)
+/// instruction.
 pub fn process_initialize_group(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -95,7 +96,7 @@ pub fn process_initialize_group(
 }
 
 /// Processes an
-/// [UpdateGroupMaxSize](enum.TokenGroupInstruction.html)
+/// [`UpdateGroupMaxSize`](enum.TokenGroupInstruction.html)
 /// instruction
 pub fn process_update_group_max_size(
     _program_id: &Pubkey,
@@ -119,7 +120,7 @@ pub fn process_update_group_max_size(
 }
 
 /// Processes an
-/// [UpdateGroupAuthority](enum.TokenGroupInstruction.html)
+/// [`UpdateGroupAuthority`](enum.TokenGroupInstruction.html)
 /// instruction
 pub fn process_update_group_authority(
     _program_id: &Pubkey,
@@ -142,7 +143,7 @@ pub fn process_update_group_authority(
     Ok(())
 }
 
-/// Processes an [InitializeMember](enum.TokenGroupInstruction.html)
+/// Processes an [`InitializeMember`](enum.TokenGroupInstruction.html)
 /// instruction
 pub fn process_initialize_member(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
@@ -204,7 +205,7 @@ pub fn process_initialize_member(_program_id: &Pubkey, accounts: &[AccountInfo])
     Ok(())
 }
 
-/// Processes an [Instruction](enum.Instruction.html).
+/// Processes an [`Instruction`](enum.Instruction.html).
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program-2022/src/extension/token_metadata/mod.rs
+++ b/token/program-2022/src/extension/token_metadata/mod.rs
@@ -3,7 +3,7 @@ use {
     spl_token_metadata_interface::state::TokenMetadata,
 };
 
-/// Instruction processor for the TokenMetadata extension
+/// Instruction processor for the `TokenMetadata` extension
 pub mod processor;
 
 impl Extension for TokenMetadata {

--- a/token/program-2022/src/extension/token_metadata/processor.rs
+++ b/token/program-2022/src/extension/token_metadata/processor.rs
@@ -43,7 +43,7 @@ fn check_update_authority(
     Ok(())
 }
 
-/// Processes a [Initialize](enum.TokenMetadataInstruction.html) instruction.
+/// Processes a [`Initialize`](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_initialize(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -106,7 +106,8 @@ pub fn process_initialize(
     Ok(())
 }
 
-/// Processes an [UpdateField](enum.TokenMetadataInstruction.html) instruction.
+/// Processes an [`UpdateField`](enum.TokenMetadataInstruction.html)
+/// instruction.
 pub fn process_update_field(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -135,7 +136,7 @@ pub fn process_update_field(
     Ok(())
 }
 
-/// Processes a [RemoveKey](enum.TokenMetadataInstruction.html) instruction.
+/// Processes a [`RemoveKey`](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_remove_key(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -161,7 +162,7 @@ pub fn process_remove_key(
     Ok(())
 }
 
-/// Processes a [UpdateAuthority](enum.TokenMetadataInstruction.html)
+/// Processes a [`UpdateAuthority`](enum.TokenMetadataInstruction.html)
 /// instruction.
 pub fn process_update_authority(
     _program_id: &Pubkey,
@@ -188,7 +189,7 @@ pub fn process_update_authority(
     Ok(())
 }
 
-/// Processes an [Emit](enum.TokenMetadataInstruction.html) instruction.
+/// Processes an [`Emit`](enum.TokenMetadataInstruction.html) instruction.
 pub fn process_emit(program_id: &Pubkey, accounts: &[AccountInfo], data: Emit) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let metadata_info = next_account_info(account_info_iter)?;
@@ -207,7 +208,7 @@ pub fn process_emit(program_id: &Pubkey, accounts: &[AccountInfo], data: Emit) -
     Ok(())
 }
 
-/// Processes an [Instruction](enum.Instruction.html).
+/// Processes an [`Instruction`](enum.Instruction.html).
 pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program-2022/src/extension/transfer_fee/instruction.rs
+++ b/token/program-2022/src/extension/transfer_fee/instruction.rs
@@ -69,15 +69,15 @@ pub enum TransferFeeInstruction {
     ///   1. `[]` The token mint.
     ///   2. `[writable]` The destination account.
     ///   3. `[]` The source account's multisignature owner/delegate.
-    ///   4. ..4+M `[signer]` M signer accounts.
+    ///   4. `..4+M` `[signer]` M signer accounts.
     TransferCheckedWithFee {
         /// The amount of tokens to transfer.
         amount: u64,
         /// Expected number of base 10 digits to the right of the decimal place.
         decimals: u8,
         /// Expected fee assessed on this transfer, calculated off-chain based
-        /// on the transfer_fee_basis_points and maximum_fee of the mint. May
-        /// be 0 for a mint without a configured transfer fee.
+        /// on the `transfer_fee_basis_points` and `maximum_fee` of the mint.
+        /// May be 0 for a mint without a configured transfer fee.
         fee: u64,
     },
     /// Transfer all withheld tokens in the mint to an account. Signed by the
@@ -96,7 +96,7 @@ pub enum TransferFeeInstruction {
     ///   0. `[writable]` The token mint.
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The mint's multisig `withdraw_withheld_authority`.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. `..3+M `[signer]` M signer accounts.
     WithdrawWithheldTokensFromMint,
     /// Transfer all withheld tokens to an account. Signed by the mint's
     /// withdraw withheld tokens authority.
@@ -110,14 +110,14 @@ pub enum TransferFeeInstruction {
     ///      `TransferFeeAmount` extension and be associated with the provided
     ///      mint.
     ///   2. `[signer]` The mint's `withdraw_withheld_authority`.
-    ///   3. ..3+N `[writable]` The source accounts to withdraw from.
+    ///   3. `..3+N` `[writable]` The source accounts to withdraw from.
     ///
     ///   * Multisignature owner/delegate
     ///   0. `[]` The token mint.
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The mint's multisig `withdraw_withheld_authority`.
-    ///   3. ..3+M `[signer]` M signer accounts.
-    ///   4. 3+M+1..3+M+N `[writable]` The source accounts to withdraw from.
+    ///   3. `..3+M` `[signer]` M signer accounts.
+    ///   4. `3+M+1..3+M+N` `[writable]` The source accounts to withdraw from.
     WithdrawWithheldTokensFromAccounts {
         /// Number of token accounts harvested
         num_token_accounts: u8,
@@ -132,7 +132,7 @@ pub enum TransferFeeInstruction {
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The mint.
-    ///   1. ..1+N `[writable]` The source accounts to harvest from.
+    ///   1. `..1+N` `[writable]` The source accounts to harvest from.
     HarvestWithheldTokensToMint,
     /// Set transfer fee. Only supported for mints that include the
     /// `TransferFeeConfig` extension.
@@ -146,7 +146,7 @@ pub enum TransferFeeInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's multisignature fee account owner.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     SetTransferFee {
         /// Amount of transfer collected as fees, expressed as basis points of
         /// the transfer amount
@@ -156,7 +156,7 @@ pub enum TransferFeeInstruction {
     },
 }
 impl TransferFeeInstruction {
-    /// Unpacks a byte buffer into a TransferFeeInstruction
+    /// Unpacks a byte buffer into a `TransferFeeInstruction`
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
         use TokenError::InvalidInstruction;
 
@@ -203,7 +203,7 @@ impl TransferFeeInstruction {
         })
     }
 
-    /// Packs a TransferFeeInstruction into a byte buffer.
+    /// Packs a `TransferFeeInstruction` into a byte buffer.
     pub fn pack(&self, buffer: &mut Vec<u8>) {
         match *self {
             Self::InitializeTransferFeeConfig {

--- a/token/program-2022/src/extension/transfer_fee/mod.rs
+++ b/token/program-2022/src/extension/transfer_fee/mod.rs
@@ -23,7 +23,7 @@ pub mod instruction;
 /// Transfer fee extension processor
 pub mod processor;
 
-/// Maximum possible fee in basis points is 100%, aka 10_000 basis points
+/// Maximum possible fee in basis points is `100%`, aka 10,000 basis points
 pub const MAX_FEE_BASIS_POINTS: u16 = 10_000;
 const ONE_IN_BASIS_POINTS: u128 = MAX_FEE_BASIS_POINTS as u128;
 
@@ -38,7 +38,7 @@ pub struct TransferFee {
     /// Maximum fee assessed on transfers, expressed as an amount of tokens
     pub maximum_fee: PodU64,
     /// Amount of transfer collected as fees, expressed as basis points of the
-    /// transfer amount, ie. increments of 0.01%
+    /// transfer amount (increments of `0.01%`)
     pub transfer_fee_basis_points: PodU16,
 }
 impl TransferFee {
@@ -80,9 +80,9 @@ impl TransferFee {
     ///
     /// The original transfer amount may not always be unique due to rounding.
     /// In this case, the smaller amount will be chosen.
-    /// e.g. Both transfer amount 10, 11 with 10% fee rate results in net
+    /// e.g. Both transfer amount 10, 11 with `10%` fee rate results in net
     /// transfer amount of 9. In this case, 10 will be chosen.
-    /// e.g. Fee rate is 100%. In this case, 0 will be chosen.
+    /// e.g. Fee rate is `100%`. In this case, 0 will be chosen.
     ///
     /// The original transfer amount may not always exist on large net transfer
     /// amounts due to overflow. In this case, `None` is returned.
@@ -141,9 +141,9 @@ pub struct TransferFeeConfig {
     /// Withheld transfer fee tokens that have been moved to the mint for
     /// withdrawal
     pub withheld_amount: PodU64,
-    /// Older transfer fee, used if the current epoch < new_transfer_fee.epoch
+    /// Older transfer fee, used if `current epoch < new_transfer_fee.epoch`
     pub older_transfer_fee: TransferFee,
-    /// Newer transfer fee, used if the current epoch >= new_transfer_fee.epoch
+    /// Newer transfer fee, used if `current epoch >= new_transfer_fee.epoch`
     pub newer_transfer_fee: TransferFee,
 }
 impl TransferFeeConfig {

--- a/token/program-2022/src/extension/transfer_hook/instruction.rs
+++ b/token/program-2022/src/extension/transfer_hook/instruction.rs
@@ -50,7 +50,7 @@ pub enum TransferHookInstruction {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint.
     ///   1. `[]` The mint's transfer hook authority.
-    ///   2. ..2+M `[signer]` M signer accounts.
+    ///   2. `..2+M` `[signer]` M signer accounts.
     ///
     /// Data expected by this instruction:
     ///   `crate::extension::transfer_hook::UpdateInstructionData`

--- a/token/program-2022/src/extension/transfer_hook/mod.rs
+++ b/token/program-2022/src/extension/transfer_hook/mod.rs
@@ -13,9 +13,9 @@ use {
     spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodBool},
 };
 
-/// Instructions for the TransferHook extension
+/// Instructions for the `TransferHook` extension
 pub mod instruction;
-/// Instruction processor for the TransferHook extension
+/// Instruction processor for the `TransferHook` extension
 pub mod processor;
 
 /// Transfer hook extension data for mints.

--- a/token/program-2022/src/generic_token_account.rs
+++ b/token/program-2022/src/generic_token_account.rs
@@ -1,4 +1,4 @@
-//! Generic Token Account, copied from spl_token::state
+//! Generic Token Account, copied from `spl_token::state`
 // Remove all of this and use spl-token's version once token 3.4.0 is released
 use {
     crate::state::AccountState,
@@ -56,7 +56,7 @@ pub trait GenericTokenAccount {
 pub const ACCOUNT_INITIALIZED_INDEX: usize = 108;
 
 /// Check if the account data buffer represents an initialized account.
-/// This is checking the `state` (AccountState) field of an Account object.
+/// This is checking the `state` (`AccountState`) field of an Account object.
 pub fn is_initialized_account(account_data: &[u8]) -> bool {
     *account_data
         .get(ACCOUNT_INITIALIZED_INDEX)

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -1951,10 +1951,26 @@ pub fn decode_instruction_type<T: TryFrom<u8>>(input: &[u8]) -> Result<T, Progra
 /// instruction type as the first byte.  This makes the code concise and safe
 /// at the expense of clarity, allowing flows such as:
 ///
-/// ```no_run
-/// match decode_instruction_type(input)? {
+/// ```
+/// use spl_token_2022::instruction::{decode_instruction_data, decode_instruction_type};
+/// use num_enum::TryFromPrimitive;
+/// use bytemuck::{Pod, Zeroable};
+///
+/// #[repr(u8)]
+/// #[derive(Clone, Copy, TryFromPrimitive)]
+/// enum InstructionType {
+///     First
+/// }
+/// #[derive(Pod, Zeroable, Copy, Clone)]
+/// #[repr(transparent)]
+/// struct FirstData {
+///     a: u8,
+/// }
+/// let input = [0, 1];
+/// match decode_instruction_type(&input).unwrap() {
 ///     InstructionType::First => {
-///         let FirstData { ... } = decode_instruction_data(input)?;
+///         let FirstData { a } = decode_instruction_data(&input).unwrap();
+///         assert_eq!(*a, 1);
 ///     }
 /// }
 /// ```

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -34,9 +34,9 @@ use {
 pub const MIN_SIGNERS: usize = 1;
 /// Maximum number of multisignature signers (max N)
 pub const MAX_SIGNERS: usize = 11;
-/// Serialized length of a u16, for unpacking
+/// Serialized length of a `u16`, for unpacking
 const U16_BYTES: usize = 2;
-/// Serialized length of a u64, for unpacking
+/// Serialized length of a `u64`, for unpacking
 const U64_BYTES: usize = 8;
 
 /// Instructions supported by the token program.
@@ -110,8 +110,8 @@ pub enum TokenInstruction<'a> {
     ///
     ///   0. `[writable]` The multisignature account to initialize.
     ///   1. `[]` Rent sysvar
-    ///   2. ..2+N. `[]` The signer accounts, must equal to N where 1 <= N <=
-    ///      11.
+    ///   2. ..`2+N`. `[]` The signer accounts, must equal to N where `1 <= N <=
+    ///      11`.
     InitializeMultisig {
         /// The number of signers (M) required to validate this multisignature
         /// account.
@@ -140,7 +140,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The source account.
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The source account's multisignature owner/delegate.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     #[deprecated(
         since = "4.0.0",
         note = "please use `TransferChecked` or `TransferCheckedWithFee` instead"
@@ -163,7 +163,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The source account.
     ///   1. `[]` The delegate.
     ///   2. `[]` The source account's multisignature owner.
-    ///   3. ..3+M `[signer]` M signer accounts
+    ///   3. ..`3+M` `[signer]` M signer accounts
     Approve {
         /// The amount of tokens the delegate is approved for.
         amount: u64,
@@ -180,7 +180,7 @@ pub enum TokenInstruction<'a> {
     ///   * Multisignature owner
     ///   0. `[writable]` The source account.
     ///   1. `[]` The source account's multisignature owner or current delegate.
-    ///   2. ..2+M `[signer]` M signer accounts
+    ///   2. ..`2+M` `[signer]` M signer accounts
     Revoke,
     /// Sets a new authority of a mint or account.
     ///
@@ -193,7 +193,7 @@ pub enum TokenInstruction<'a> {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint or account to change the authority of.
     ///   1. `[]` The mint's or account's current multisignature authority.
-    ///   2. ..2+M `[signer]` M signer accounts
+    ///   2. ..`2+M` `[signer]` M signer accounts
     SetAuthority {
         /// The type of authority to update.
         authority_type: AuthorityType,
@@ -215,7 +215,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The mint.
     ///   1. `[writable]` The account to mint tokens to.
     ///   2. `[]` The mint's multisignature mint-tokens authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     MintTo {
         /// The amount of new tokens to mint.
         amount: u64,
@@ -234,7 +234,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to burn from.
     ///   1. `[writable]` The token mint.
     ///   2. `[]` The account's multisignature owner/delegate.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     Burn {
         /// The amount of tokens to burn.
         amount: u64,
@@ -272,10 +272,10 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to close.
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The account's multisignature owner.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     CloseAccount,
     // 10
-    /// Freeze an Initialized account using the Mint's freeze_authority (if
+    /// Freeze an Initialized account using the Mint's `freeze_authority` (if
     /// set).
     ///
     /// Accounts expected by this instruction:
@@ -289,9 +289,9 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to freeze.
     ///   1. `[]` The token mint.
     ///   2. `[]` The mint's multisignature freeze authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     FreezeAccount,
-    /// Thaw a Frozen account using the Mint's freeze_authority (if set).
+    /// Thaw a Frozen account using the Mint's `freeze_authority` (if set).
     ///
     /// Accounts expected by this instruction:
     ///
@@ -304,7 +304,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to freeze.
     ///   1. `[]` The token mint.
     ///   2. `[]` The mint's multisignature freeze authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     ThawAccount,
 
     /// Transfers tokens from one account to another either directly or via a
@@ -312,7 +312,7 @@ pub enum TokenInstruction<'a> {
     /// amounts of SOL and Tokens will be transferred to the destination
     /// account.
     ///
-    /// This instruction differs from Transfer in that the token mint and
+    /// This instruction differs from `Transfer` in that the token mint and
     /// decimals value is checked by the caller.  This may be useful when
     /// creating transactions offline or within a hardware wallet.
     ///
@@ -332,7 +332,7 @@ pub enum TokenInstruction<'a> {
     ///   1. `[]` The token mint.
     ///   2. `[writable]` The destination account.
     ///   3. `[]` The source account's multisignature owner/delegate.
-    ///   4. ..4+M `[signer]` M signer accounts.
+    ///   4. ..`4+M` `[signer]` M signer accounts.
     TransferChecked {
         /// The amount of tokens to transfer.
         amount: u64,
@@ -342,7 +342,7 @@ pub enum TokenInstruction<'a> {
     /// Approves a delegate.  A delegate is given the authority over tokens on
     /// behalf of the source account's owner.
     ///
-    /// This instruction differs from Approve in that the token mint and
+    /// This instruction differs from `Approve` in that the token mint and
     /// decimals value is checked by the caller.  This may be useful when
     /// creating transactions offline or within a hardware wallet.
     ///
@@ -359,7 +359,7 @@ pub enum TokenInstruction<'a> {
     ///   1. `[]` The token mint.
     ///   2. `[]` The delegate.
     ///   3. `[]` The source account's multisignature owner.
-    ///   4. ..4+M `[signer]` M signer accounts
+    ///   4. ..`4+M` `[signer]` M signer accounts
     ApproveChecked {
         /// The amount of tokens the delegate is approved for.
         amount: u64,
@@ -369,7 +369,7 @@ pub enum TokenInstruction<'a> {
     /// Mints new tokens to an account.  The native mint does not support
     /// minting.
     ///
-    /// This instruction differs from MintTo in that the decimals value is
+    /// This instruction differs from `MintTo` in that the decimals value is
     /// checked by the caller.  This may be useful when creating transactions
     /// offline or within a hardware wallet.
     ///
@@ -384,7 +384,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The mint.
     ///   1. `[writable]` The account to mint tokens to.
     ///   2. `[]` The mint's multisignature mint-tokens authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     MintToChecked {
         /// The amount of new tokens to mint.
         amount: u64,
@@ -396,9 +396,9 @@ pub enum TokenInstruction<'a> {
     /// support accounts associated with the native mint, use `CloseAccount`
     /// instead.
     ///
-    /// This instruction differs from Burn in that the decimals value is checked
-    /// by the caller. This may be useful when creating transactions offline or
-    /// within a hardware wallet.
+    /// This instruction differs from `Burn` in that the decimals value is
+    /// checked by the caller. This may be useful when creating transactions
+    /// offline or within a hardware wallet.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -411,14 +411,14 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to burn from.
     ///   1. `[writable]` The token mint.
     ///   2. `[]` The account's multisignature owner/delegate.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     BurnChecked {
         /// The amount of tokens to burn.
         amount: u64,
         /// Expected number of base 10 digits to the right of the decimal place.
         decimals: u8,
     },
-    /// Like InitializeAccount, but the owner pubkey is passed via instruction
+    /// Like `InitializeAccount`, but the owner pubkey is passed via instruction
     /// data rather than the accounts list. This variant may be preferable
     /// when using Cross Program Invocation from an instruction that does
     /// not need the owner's `AccountInfo` otherwise.
@@ -444,7 +444,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]`  The native token account to sync with its underlying
     ///      lamports.
     SyncNative,
-    /// Like InitializeAccount2, but does not require the Rent sysvar to be
+    /// Like `InitializeAccount2`, but does not require the Rent sysvar to be
     /// provided
     ///
     /// Accounts expected by this instruction:
@@ -456,21 +456,22 @@ pub enum TokenInstruction<'a> {
         #[cfg_attr(feature = "serde-traits", serde(with = "As::<DisplayFromStr>"))]
         owner: Pubkey,
     },
-    /// Like InitializeMultisig, but does not require the Rent sysvar to be
+    /// Like `InitializeMultisig`, but does not require the Rent sysvar to be
     /// provided
     ///
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The multisignature account to initialize.
-    ///   1. ..1+N. `[]` The signer accounts, must equal to N where 1 <= N <=
-    ///      11.
+    ///   1. ..`1+N`. `[]` The signer accounts, must equal to N where `1 <= N <=
+    ///      11`.
     InitializeMultisig2 {
         /// The number of signers (M) required to validate this multisignature
         /// account.
         m: u8,
     },
     // 20
-    /// Like InitializeMint, but does not require the Rent sysvar to be provided
+    /// Like `InitializeMint`, but does not require the Rent sysvar to be
+    /// provided
     ///
     /// Accounts expected by this instruction:
     ///
@@ -510,7 +511,7 @@ pub enum TokenInstruction<'a> {
     /// Data expected by this instruction:
     ///   None
     InitializeImmutableOwner,
-    /// Convert an Amount of tokens to a UiAmount `string`, using the given
+    /// Convert an Amount of tokens to a `UiAmount` string, using the given
     /// mint.
     ///
     /// Fails on an invalid mint.
@@ -525,8 +526,8 @@ pub enum TokenInstruction<'a> {
         /// The amount of tokens to convert.
         amount: u64,
     },
-    /// Convert a UiAmount of tokens to a little-endian `u64` raw Amount, using
-    /// the given mint.
+    /// Convert a `UiAmount` of tokens to a little-endian `u64` raw Amount,
+    /// using the given mint.
     ///
     /// Return data can be fetched using `sol_get_return_data` and deserializing
     /// the return data as a little-endian `u64`.
@@ -535,7 +536,7 @@ pub enum TokenInstruction<'a> {
     ///
     ///   0. `[]` The mint to calculate for
     UiAmountToAmount {
-        /// The ui_amount of tokens to convert.
+        /// The `ui_amount` of tokens to convert.
         ui_amount: &'a str,
     },
     // 25
@@ -577,7 +578,7 @@ pub enum TokenInstruction<'a> {
     /// instruction prefix
     DefaultAccountStateExtension,
     /// Check to see if a token account is large enough for a list of
-    /// ExtensionTypes, and if not, use reallocation to increase the data
+    /// `ExtensionTypes`, and if not, use reallocation to increase the data
     /// size.
     ///
     /// Accounts expected by this instruction:
@@ -593,7 +594,7 @@ pub enum TokenInstruction<'a> {
     ///   1. `[signer, writable]` The payer account to fund reallocation
     ///   2. `[]` System program for reallocation funding
     ///   3. `[]` The account's multisignature owner/delegate.
-    ///   4. ..4+M `[signer]` M signer accounts.
+    ///   4. ..`4+M` `[signer]` M signer accounts.
     Reallocate {
         /// New extension types to include in the reallocated account
         extension_types: Vec<ExtensionType>,
@@ -678,14 +679,14 @@ pub enum TokenInstruction<'a> {
     /// for further details about the extended instructions that share this
     /// instruction prefix
     ConfidentialTransferFeeExtension,
-    /// This instruction is to be used to rescue SOLs sent to any TokenProgram
+    /// This instruction is to be used to rescue SOL sent to any `TokenProgram`
     /// owned account by sending them to any other account, leaving behind only
     /// lamports for rent exemption.
     ///
     /// 0. `[writable]` Source Account owned by the token program
     /// 1. `[writable]` Destination account
     /// 2. `[signer]` Authority
-    /// 3. ..2+M `[signer]` M signer accounts.
+    /// 3. ..`3+M` `[signer]` M signer accounts.
     WithdrawExcessLamports,
     /// The common instruction prefix for metadata pointer extension
     /// instructions.
@@ -714,7 +715,7 @@ pub enum TokenInstruction<'a> {
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a
-    /// [TokenInstruction](enum.TokenInstruction.html).
+    /// [`TokenInstruction`](enum.TokenInstruction.html).
     pub fn unpack(input: &'a [u8]) -> Result<Self, ProgramError> {
         use TokenError::InvalidInstruction;
 
@@ -855,7 +856,7 @@ impl<'a> TokenInstruction<'a> {
         })
     }
 
-    /// Packs a [TokenInstruction](enum.TokenInstruction.html) into a byte
+    /// Packs a [`TokenInstruction`](enum.TokenInstruction.html) into a byte
     /// buffer.
     pub fn pack(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(size_of::<Self>());
@@ -1085,7 +1086,7 @@ impl<'a> TokenInstruction<'a> {
     }
 }
 
-/// Specifies the authority type for SetAuthority instructions
+/// Specifies the authority type for `SetAuthority` instructions
 #[repr(u8)]
 #[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
@@ -1109,7 +1110,7 @@ pub enum AuthorityType {
     InterestRate,
     /// Authority to transfer or burn any tokens for a mint
     PermanentDelegate,
-    /// Authority to update confidential transfer mint and aprove accounts for
+    /// Authority to update confidential transfer mint and approve accounts for
     /// confidential transfers
     ConfidentialTransferMint,
     /// Authority to set the transfer hook program id
@@ -1929,7 +1930,8 @@ pub fn initialize_permanent_delegate(
     })
 }
 
-/// Utility function that checks index is between MIN_SIGNERS and MAX_SIGNERS
+/// Utility function that checks index is between `MIN_SIGNERS` and
+/// `MAX_SIGNERS`
 pub fn is_valid_signer_index(index: usize) -> bool {
     (MIN_SIGNERS..=MAX_SIGNERS).contains(&index)
 }
@@ -1949,11 +1951,13 @@ pub fn decode_instruction_type<T: TryFrom<u8>>(input: &[u8]) -> Result<T, Progra
 /// instruction type as the first byte.  This makes the code concise and safe
 /// at the expense of clarity, allowing flows such as:
 ///
+/// ```no_run
 /// match decode_instruction_type(input)? {
 ///     InstructionType::First => {
 ///         let FirstData { ... } = decode_instruction_data(input)?;
 ///     }
 /// }
+/// ```
 pub fn decode_instruction_data<T: Pod>(input_with_type: &[u8]) -> Result<&T, ProgramError> {
     if input_with_type.len() != pod_get_packed_len::<T>().saturating_add(1) {
         Err(ProgramError::InvalidInstructionData)

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -126,7 +126,7 @@ pub fn check_zk_elgamal_proof_program_account(
     Ok(())
 }
 
-/// Checks if the spplied program ID is that of the system program
+/// Checks if the supplied program ID is that of the system program
 pub fn check_system_program_account(system_program_id: &Pubkey) -> ProgramResult {
     if system_program_id != &system_program::id() {
         return Err(ProgramError::IncorrectProgramId);

--- a/token/program-2022/src/native_mint.rs
+++ b/token/program-2022/src/native_mint.rs
@@ -1,12 +1,12 @@
 //! The Mint that represents the native token
 
-/// There are 10^9 lamports in one SOL
+/// There are `10^9` lamports in one SOL
 pub const DECIMALS: u8 = 9;
 
 // The Mint for native SOL Token accounts
 solana_program::declare_id!("9pan9bMn5HatX4EJdBwg9VgCa7Uz5HL8N1m5D3NdXejP");
 
-/// Seed for the native_mint's program-derived address
+/// Seed for the native mint's program-derived address
 pub const PROGRAM_ADDRESS_SEEDS: &[&[u8]] = &["native-mint".as_bytes(), &[255]];
 
 #[cfg(test)]

--- a/token/program-2022/src/pod.rs
+++ b/token/program-2022/src/pod.rs
@@ -71,9 +71,9 @@ pub struct PodAccount {
     /// If `delegate` is `Some` then `delegated_amount` represents
     /// the amount authorized by the delegate
     pub delegate: PodCOption<Pubkey>,
-    /// The account's [AccountState], stored as a u8
+    /// The account's [`AccountState`], stored as a `u8`
     pub state: u8,
-    /// If is_some, this is a native token, and the value logs the rent-exempt
+    /// If `is_some`, this is a native token, and the value logs the rent-exempt
     /// reserve. An Account is required to be rent-exempt, so the value is
     /// used by the Processor to ensure that wrapped SOL accounts do not
     /// drop below this threshold.
@@ -92,7 +92,7 @@ impl PodAccount {
     pub fn is_native(&self) -> bool {
         self.is_native.is_some()
     }
-    /// Checks if a token Account's owner is the system_program or the
+    /// Checks if a token Account's owner is the `system_program` or the
     /// incinerator
     pub fn is_owned_by_system_program_or_incinerator(&self) -> bool {
         solana_program::system_program::check_id(&self.owner)
@@ -156,7 +156,7 @@ impl From<Multisig> for PodMultisig {
     }
 }
 
-/// COption<T> stored as a Pod type
+/// `COption<T>` stored as a Pod type
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct PodCOption<T>
@@ -176,7 +176,7 @@ where
     /// `Option::Some(v)`
     pub const SOME: [u8; 4] = [1, 0, 0, 0];
 
-    /// Create a PodCOption equivalent of `Option::None`
+    /// Create a `PodCOption` equivalent of `Option::None`
     ///
     /// This could be made `const` by using `std::mem::zeroed`, but that would
     /// require `unsafe` code, which is prohibited at the crate level.
@@ -187,7 +187,7 @@ where
         }
     }
 
-    /// Create a PodCOption equivalent of `Option::Some(value)`
+    /// Create a `PodCOption` equivalent of `Option::Some(value)`
     pub const fn some(value: T) -> Self {
         Self {
             option: Self::SOME,

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -108,7 +108,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeMint](enum.TokenInstruction.html) instruction.
+    /// Processes an [`InitializeMint`](enum.TokenInstruction.html) instruction.
     pub fn process_initialize_mint(
         accounts: &[AccountInfo],
         decimals: u8,
@@ -118,7 +118,8 @@ impl Processor {
         Self::_process_initialize_mint(accounts, decimals, mint_authority, freeze_authority, true)
     }
 
-    /// Processes an [InitializeMint2](enum.TokenInstruction.html) instruction.
+    /// Processes an [`InitializeMint2`](enum.TokenInstruction.html)
+    /// instruction.
     pub fn process_initialize_mint2(
         accounts: &[AccountInfo],
         decimals: u8,
@@ -211,19 +212,19 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeAccount](enum.TokenInstruction.html)
+    /// Processes an [`InitializeAccount`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_account(accounts: &[AccountInfo]) -> ProgramResult {
         Self::_process_initialize_account(accounts, None, true)
     }
 
-    /// Processes an [InitializeAccount2](enum.TokenInstruction.html)
+    /// Processes an [`InitializeAccount2`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_account2(accounts: &[AccountInfo], owner: &Pubkey) -> ProgramResult {
         Self::_process_initialize_account(accounts, Some(owner), true)
     }
 
-    /// Processes an [InitializeAccount3](enum.TokenInstruction.html)
+    /// Processes an [`InitializeAccount3`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_account3(accounts: &[AccountInfo], owner: &Pubkey) -> ProgramResult {
         Self::_process_initialize_account(accounts, Some(owner), false)
@@ -270,19 +271,19 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [InitializeMultisig](enum.TokenInstruction.html)
+    /// Processes a [`InitializeMultisig`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_multisig(accounts: &[AccountInfo], m: u8) -> ProgramResult {
         Self::_process_initialize_multisig(accounts, m, true)
     }
 
-    /// Processes a [InitializeMultisig2](enum.TokenInstruction.html)
+    /// Processes a [`InitializeMultisig2`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_multisig2(accounts: &[AccountInfo], m: u8) -> ProgramResult {
         Self::_process_initialize_multisig(accounts, m, false)
     }
 
-    /// Processes a [Transfer](enum.TokenInstruction.html) instruction.
+    /// Processes a [`Transfer`](enum.TokenInstruction.html) instruction.
     pub fn process_transfer(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -544,7 +545,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Approve](enum.TokenInstruction.html) instruction.
+    /// Processes an [`Approve`](enum.TokenInstruction.html) instruction.
     pub fn process_approve(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -604,7 +605,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Revoke](enum.TokenInstruction.html) instruction.
+    /// Processes an [`Revoke`](enum.TokenInstruction.html) instruction.
     pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let source_account_info = next_account_info(account_info_iter)?;
@@ -638,7 +639,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [SetAuthority](enum.TokenInstruction.html) instruction.
+    /// Processes a [`SetAuthority`](enum.TokenInstruction.html) instruction.
     pub fn process_set_authority(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -916,7 +917,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [MintTo](enum.TokenInstruction.html) instruction.
+    /// Processes a [`MintTo`](enum.TokenInstruction.html) instruction.
     pub fn process_mint_to(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -999,7 +1000,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [Burn](enum.TokenInstruction.html) instruction.
+    /// Processes a [`Burn`](enum.TokenInstruction.html) instruction.
     pub fn process_burn(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1121,7 +1122,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [CloseAccount](enum.TokenInstruction.html) instruction.
+    /// Processes a [`CloseAccount`](enum.TokenInstruction.html) instruction.
     pub fn process_close_account(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let source_account_info = next_account_info(account_info_iter)?;
@@ -1216,8 +1217,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [FreezeAccount](enum.TokenInstruction.html) or a
-    /// [ThawAccount](enum.TokenInstruction.html) instruction.
+    /// Processes a [`FreezeAccount`](enum.TokenInstruction.html) or a
+    /// [`ThawAccount`](enum.TokenInstruction.html) instruction.
     pub fn process_toggle_freeze_account(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1268,7 +1269,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [SyncNative](enum.TokenInstruction.html) instruction
+    /// Processes a [`SyncNative`](enum.TokenInstruction.html) instruction
     pub fn process_sync_native(accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let native_account_info = next_account_info(account_info_iter)?;
@@ -1298,7 +1299,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeMintCloseAuthority](enum.TokenInstruction.html)
+    /// Processes an
+    /// [`InitializeMintCloseAuthority`](enum.TokenInstruction.html)
     /// instruction
     pub fn process_initialize_mint_close_authority(
         accounts: &[AccountInfo],
@@ -1315,7 +1317,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [GetAccountDataSize](enum.TokenInstruction.html) instruction
+    /// Processes a [`GetAccountDataSize`](enum.TokenInstruction.html)
+    /// instruction
     pub fn process_get_account_data_size(
         accounts: &[AccountInfo],
         new_extension_types: &[ExtensionType],
@@ -1341,7 +1344,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeImmutableOwner](enum.TokenInstruction.html)
+    /// Processes an [`InitializeImmutableOwner`](enum.TokenInstruction.html)
     /// instruction
     pub fn process_initialize_immutable_owner(accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
@@ -1354,7 +1357,8 @@ impl Processor {
             .map(|_| ())
     }
 
-    /// Processes an [AmountToUiAmount](enum.TokenInstruction.html) instruction
+    /// Processes an [`AmountToUiAmount`](enum.TokenInstruction.html)
+    /// instruction
     pub fn process_amount_to_ui_amount(accounts: &[AccountInfo], amount: u64) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let mint_info = next_account_info(account_info_iter)?;
@@ -1376,7 +1380,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [AmountToUiAmount](enum.TokenInstruction.html) instruction
+    /// Processes an [`AmountToUiAmount`](enum.TokenInstruction.html)
+    /// instruction
     pub fn process_ui_amount_to_amount(accounts: &[AccountInfo], ui_amount: &str) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let mint_info = next_account_info(account_info_iter)?;
@@ -1396,7 +1401,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [CreateNativeMint](enum.TokenInstruction.html) instruction
+    /// Processes a [`CreateNativeMint`](enum.TokenInstruction.html) instruction
     pub fn process_create_native_mint(accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let payer_info = next_account_info(account_info_iter)?;
@@ -1441,7 +1446,8 @@ impl Processor {
         )
     }
 
-    /// Processes an [InitializeNonTransferableMint](enum.TokenInstruction.html)
+    /// Processes an
+    /// [`InitializeNonTransferableMint`](enum.TokenInstruction.html)
     /// instruction
     pub fn process_initialize_non_transferable_mint(accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
@@ -1454,7 +1460,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializePermanentDelegate](enum.TokenInstruction.html)
+    /// Processes an [`InitializePermanentDelegate`](enum.TokenInstruction.html)
     /// instruction
     pub fn process_initialize_permanent_delegate(
         accounts: &[AccountInfo],
@@ -1472,7 +1478,7 @@ impl Processor {
     }
 
     /// Withdraw Excess Lamports is used to recover Lamports transferred to any
-    /// TokenProgram owned account by moving them to another account
+    /// `TokenProgram` owned account by moving them to another account
     /// of the source account.
     pub fn process_withdraw_excess_lamports(
         program_id: &Pubkey,
@@ -1545,7 +1551,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Instruction](enum.Instruction.html).
+    /// Processes an [`Instruction`](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
         if let Ok(instruction_type) = decode_instruction_type(input) {
             match instruction_type {

--- a/token/program-2022/src/serialization.rs
+++ b/token/program-2022/src/serialization.rs
@@ -1,7 +1,7 @@
-//! serialization module - contains helpers for serde types from other crates,
+//! Serialization module - contains helpers for serde types from other crates,
 //! deserialization visitors
 
-/// helper function to ser/deser COption wrapped values
+/// Helper function to serialize / deserialize `COption` wrapped values
 pub mod coption_fromstr {
     use {
         serde::{
@@ -16,7 +16,7 @@ pub mod coption_fromstr {
         },
     };
 
-    /// serialize values supporting Display trait wrapped in COption
+    /// Serialize values supporting `Display` trait wrapped in `COption`
     pub fn serialize<S, T>(x: &COption<T>, s: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -66,7 +66,7 @@ pub mod coption_fromstr {
         }
     }
 
-    /// deserialize values supporting Display trait wrapped in COption
+    /// Deserialize values supporting `Display` trait wrapped in `COption`
     pub fn deserialize<'de, D, T>(d: D) -> Result<COption<T>, D::Error>
     where
         D: Deserializer<'de>,
@@ -76,7 +76,7 @@ pub mod coption_fromstr {
     }
 }
 
-/// helper to ser/deser PodAeCiphertext values
+/// Helper to serialize / deserialize `PodAeCiphertext` values
 pub mod aeciphertext_fromstr {
     use {
         serde::{
@@ -87,7 +87,7 @@ pub mod aeciphertext_fromstr {
         std::{fmt, str::FromStr},
     };
 
-    /// serialize AeCiphertext values supporting Display trait
+    /// Serialize `AeCiphertext` values supporting `Display` trait
     pub fn serialize<S>(x: &PodAeCiphertext, s: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -112,7 +112,7 @@ pub mod aeciphertext_fromstr {
         }
     }
 
-    /// deserialize AeCiphertext values from str
+    /// Deserialize `AeCiphertext` values from `str`
     pub fn deserialize<'de, D>(d: D) -> Result<PodAeCiphertext, D::Error>
     where
         D: Deserializer<'de>,
@@ -121,7 +121,7 @@ pub mod aeciphertext_fromstr {
     }
 }
 
-/// helper to ser/deser PodElGamalPubkey values
+/// Helper to serialize / deserialize `PodElGamalPubkey` values
 pub mod elgamalpubkey_fromstr {
     use {
         serde::{
@@ -132,7 +132,7 @@ pub mod elgamalpubkey_fromstr {
         std::{fmt, str::FromStr},
     };
 
-    /// serialize ElGamalPubkey values supporting Display trait
+    /// Serialize `ElGamalPubkey` values supporting `Display` trait
     pub fn serialize<S>(x: &PodElGamalPubkey, s: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -157,7 +157,7 @@ pub mod elgamalpubkey_fromstr {
         }
     }
 
-    /// deserialize ElGamalPubkey values from str
+    /// Deserialize `ElGamalPubkey` values from `str`
     pub fn deserialize<'de, D>(d: D) -> Result<PodElGamalPubkey, D::Error>
     where
         D: Deserializer<'de>,
@@ -166,7 +166,7 @@ pub mod elgamalpubkey_fromstr {
     }
 }
 
-/// helper to ser/deser PodElGamalCiphertext values
+/// Helper to serialize / deserialize `PodElGamalCiphertext` values
 pub mod elgamalciphertext_fromstr {
     use {
         serde::{
@@ -177,7 +177,7 @@ pub mod elgamalciphertext_fromstr {
         std::{fmt, str::FromStr},
     };
 
-    /// serialize ElGamalCiphertext values supporting Display trait
+    /// Serialize `ElGamalCiphertext` values supporting `Display` trait
     pub fn serialize<S>(x: &PodElGamalCiphertext, s: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -202,7 +202,7 @@ pub mod elgamalciphertext_fromstr {
         }
     }
 
-    /// deserialize ElGamalCiphertext values from str
+    /// Deserialize `ElGamalCiphertext` values from `str`
     pub fn deserialize<'de, D>(d: D) -> Result<PodElGamalCiphertext, D::Error>
     where
         D: Deserializer<'de>,

--- a/token/program-2022/src/state.rs
+++ b/token/program-2022/src/state.rs
@@ -113,7 +113,7 @@ pub struct Account {
     pub delegate: COption<Pubkey>,
     /// The account's state
     pub state: AccountState,
-    /// If is_some, this is a native token, and the value logs the rent-exempt
+    /// If `is_some`, this is a native token, and the value logs the rent-exempt
     /// reserve. An Account is required to be rent-exempt, so the value is
     /// used by the Processor to ensure that wrapped SOL accounts do not
     /// drop below this threshold.
@@ -132,7 +132,7 @@ impl Account {
     pub fn is_native(&self) -> bool {
         self.is_native.is_some()
     }
-    /// Checks if a token Account's owner is the system_program or the
+    /// Checks if a token Account's owner is the `system_program` or the
     /// incinerator
     pub fn is_owned_by_system_program_or_incinerator(&self) -> bool {
         solana_program::system_program::check_id(&self.owner)

--- a/token/program/README.md
+++ b/token/program/README.md
@@ -5,7 +5,7 @@ A token program on the Solana blockchain, usable for fungible and non-fungible t
 This program provides an interface and implementation that third parties can
 utilize to create and use their tokens.
 
-Full documentation is available at https://spl.solana.com/token
+Full documentation is available at the [SPL Token docs](https://spl.solana.com/token).
 
 ## Audit
 

--- a/token/program/src/instruction.rs
+++ b/token/program/src/instruction.rs
@@ -16,7 +16,7 @@ use {
 pub const MIN_SIGNERS: usize = 1;
 /// Maximum number of multisignature signers (max N)
 pub const MAX_SIGNERS: usize = 11;
-/// Serialized length of a u64, for unpacking
+/// Serialized length of a `u64`, for unpacking
 const U64_BYTES: usize = 8;
 
 /// Instructions supported by the token program.
@@ -80,8 +80,8 @@ pub enum TokenInstruction<'a> {
     ///
     ///   0. `[writable]` The multisignature account to initialize.
     ///   1. `[]` Rent sysvar
-    ///   2. ..2+N. `[]` The signer accounts, must equal to N where 1 <= N <=
-    ///      11.
+    ///   2. ..`2+N`. `[]` The signer accounts, must equal to N where `1 <= N <=
+    ///      11`.
     InitializeMultisig {
         /// The number of signers (M) required to validate this multisignature
         /// account.
@@ -103,7 +103,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The source account.
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The source account's multisignature owner/delegate.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     Transfer {
         /// The amount of tokens to transfer.
         amount: u64,
@@ -122,7 +122,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The source account.
     ///   1. `[]` The delegate.
     ///   2. `[]` The source account's multisignature owner.
-    ///   3. ..3+M `[signer]` M signer accounts
+    ///   3. ..`3+M` `[signer]` M signer accounts
     Approve {
         /// The amount of tokens the delegate is approved for.
         amount: u64,
@@ -138,7 +138,7 @@ pub enum TokenInstruction<'a> {
     ///   * Multisignature owner
     ///   0. `[writable]` The source account.
     ///   1. `[]` The source account's multisignature owner.
-    ///   2. ..2+M `[signer]` M signer accounts
+    ///   2. ..`2+M` `[signer]` M signer accounts
     Revoke,
     /// Sets a new authority of a mint or account.
     ///
@@ -151,7 +151,7 @@ pub enum TokenInstruction<'a> {
     ///   * Multisignature authority
     ///   0. `[writable]` The mint or account to change the authority of.
     ///   1. `[]` The mint's or account's current multisignature authority.
-    ///   2. ..2+M `[signer]` M signer accounts
+    ///   2. ..`2+M` `[signer]` M signer accounts
     SetAuthority {
         /// The type of authority to update.
         authority_type: AuthorityType,
@@ -172,7 +172,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The mint.
     ///   1. `[writable]` The account to mint tokens to.
     ///   2. `[]` The mint's multisignature mint-tokens authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     MintTo {
         /// The amount of new tokens to mint.
         amount: u64,
@@ -191,7 +191,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to burn from.
     ///   1. `[writable]` The token mint.
     ///   2. `[]` The account's multisignature owner/delegate.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     Burn {
         /// The amount of tokens to burn.
         amount: u64,
@@ -210,9 +210,9 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to close.
     ///   1. `[writable]` The destination account.
     ///   2. `[]` The account's multisignature owner.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     CloseAccount,
-    /// Freeze an Initialized account using the Mint's freeze_authority (if
+    /// Freeze an Initialized account using the Mint's `freeze_authority` (if
     /// set).
     ///
     /// Accounts expected by this instruction:
@@ -226,9 +226,9 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to freeze.
     ///   1. `[]` The token mint.
     ///   2. `[]` The mint's multisignature freeze authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     FreezeAccount,
-    /// Thaw a Frozen account using the Mint's freeze_authority (if set).
+    /// Thaw a Frozen account using the Mint's `freeze_authority` (if set).
     ///
     /// Accounts expected by this instruction:
     ///
@@ -241,7 +241,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to freeze.
     ///   1. `[]` The token mint.
     ///   2. `[]` The mint's multisignature freeze authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     ThawAccount,
 
     /// Transfers tokens from one account to another either directly or via a
@@ -266,7 +266,7 @@ pub enum TokenInstruction<'a> {
     ///   1. `[]` The token mint.
     ///   2. `[writable]` The destination account.
     ///   3. `[]` The source account's multisignature owner/delegate.
-    ///   4. ..4+M `[signer]` M signer accounts.
+    ///   4. ..`4+M` `[signer]` M signer accounts.
     TransferChecked {
         /// The amount of tokens to transfer.
         amount: u64,
@@ -293,7 +293,7 @@ pub enum TokenInstruction<'a> {
     ///   1. `[]` The token mint.
     ///   2. `[]` The delegate.
     ///   3. `[]` The source account's multisignature owner.
-    ///   4. ..4+M `[signer]` M signer accounts
+    ///   4. ..`4+M` `[signer]` M signer accounts
     ApproveChecked {
         /// The amount of tokens the delegate is approved for.
         amount: u64,
@@ -303,8 +303,8 @@ pub enum TokenInstruction<'a> {
     /// Mints new tokens to an account.  The native mint does not support
     /// minting.
     ///
-    /// This instruction differs from MintTo in that the decimals value is
-    /// checked by the caller.  This may be useful when creating transactions
+    /// This instruction differs from `MintTo` in that the decimals value is
+    /// checked by the caller. This may be useful when creating transactions
     /// offline or within a hardware wallet.
     ///
     /// Accounts expected by this instruction:
@@ -318,7 +318,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The mint.
     ///   1. `[writable]` The account to mint tokens to.
     ///   2. `[]` The mint's multisignature mint-tokens authority.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     MintToChecked {
         /// The amount of new tokens to mint.
         amount: u64,
@@ -344,17 +344,17 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]` The account to burn from.
     ///   1. `[writable]` The token mint.
     ///   2. `[]` The account's multisignature owner/delegate.
-    ///   3. ..3+M `[signer]` M signer accounts.
+    ///   3. ..`3+M` `[signer]` M signer accounts.
     BurnChecked {
         /// The amount of tokens to burn.
         amount: u64,
         /// Expected number of base 10 digits to the right of the decimal place.
         decimals: u8,
     },
-    /// Like InitializeAccount, but the owner pubkey is passed via instruction
-    /// data rather than the accounts list. This variant may be preferable
-    /// when using Cross Program Invocation from an instruction that does
-    /// not need the owner's `AccountInfo` otherwise.
+    /// Like [`InitializeAccount`], but the owner pubkey is passed via
+    /// instruction data rather than the accounts list. This variant may be
+    /// preferable when using Cross Program Invocation from an instruction
+    /// that does not need the owner's `AccountInfo` otherwise.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -376,7 +376,7 @@ pub enum TokenInstruction<'a> {
     ///   0. `[writable]`  The native token account to sync with its underlying
     ///      lamports.
     SyncNative,
-    /// Like InitializeAccount2, but does not require the Rent sysvar to be
+    /// Like [`InitializeAccount2`], but does not require the Rent sysvar to be
     /// provided
     ///
     /// Accounts expected by this instruction:
@@ -387,14 +387,14 @@ pub enum TokenInstruction<'a> {
         /// The new account's owner/multisignature.
         owner: Pubkey,
     },
-    /// Like InitializeMultisig, but does not require the Rent sysvar to be
+    /// Like [`InitializeMultisig`], but does not require the Rent sysvar to be
     /// provided
     ///
     /// Accounts expected by this instruction:
     ///
     ///   0. `[writable]` The multisignature account to initialize.
-    ///   1. ..1+N. `[]` The signer accounts, must equal to N where 1 <= N <=
-    ///      11.
+    ///   1. ..`1+N` `[]` The signer accounts, must equal to N where `1 <= N <=
+    ///      11`.
     InitializeMultisig2 {
         /// The number of signers (M) required to validate this multisignature
         /// account.
@@ -439,7 +439,7 @@ pub enum TokenInstruction<'a> {
     /// Data expected by this instruction:
     ///   None
     InitializeImmutableOwner,
-    /// Convert an Amount of tokens to a UiAmount `string`, using the given
+    /// Convert an Amount of tokens to a `UiAmount` string, using the given
     /// mint. In this version of the program, the mint can only specify the
     /// number of decimals.
     ///
@@ -455,9 +455,9 @@ pub enum TokenInstruction<'a> {
         /// The amount of tokens to reformat.
         amount: u64,
     },
-    /// Convert a UiAmount of tokens to a little-endian `u64` raw Amount, using
-    /// the given mint. In this version of the program, the mint can only
-    /// specify the number of decimals.
+    /// Convert a `UiAmount` of tokens to a little-endian `u64` raw Amount,
+    /// using the given mint. In this version of the program, the mint can
+    /// only specify the number of decimals.
     ///
     /// Return data can be fetched using `sol_get_return_data` and deserializing
     /// the return data as a little-endian `u64`.
@@ -466,7 +466,7 @@ pub enum TokenInstruction<'a> {
     ///
     ///   0. `[]` The mint to calculate for
     UiAmountToAmount {
-        /// The ui_amount of tokens to reformat.
+        /// The `ui_amount` of tokens to reformat.
         ui_amount: &'a str,
     },
     // Any new variants also need to be added to program-2022 `TokenInstruction`, so that the
@@ -475,7 +475,7 @@ pub enum TokenInstruction<'a> {
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a
-    /// [TokenInstruction](enum.TokenInstruction.html).
+    /// [`TokenInstruction`](enum.TokenInstruction.html).
     pub fn unpack(input: &'a [u8]) -> Result<Self, ProgramError> {
         use TokenError::InvalidInstruction;
 
@@ -579,7 +579,7 @@ impl<'a> TokenInstruction<'a> {
         })
     }
 
-    /// Packs a [TokenInstruction](enum.TokenInstruction.html) into a byte
+    /// Packs a [`TokenInstruction`](enum.TokenInstruction.html) into a byte
     /// buffer.
     pub fn pack(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(size_of::<Self>());
@@ -738,7 +738,7 @@ impl<'a> TokenInstruction<'a> {
     }
 }
 
-/// Specifies the authority type for SetAuthority instructions
+/// Specifies the authority type for `SetAuthority` instructions
 #[repr(u8)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum AuthorityType {
@@ -1431,7 +1431,8 @@ pub fn ui_amount_to_amount(
     })
 }
 
-/// Utility function that checks index is between MIN_SIGNERS and MAX_SIGNERS
+/// Utility function that checks index is between `MIN_SIGNERS` and
+/// `MAX_SIGNERS`
 pub fn is_valid_signer_index(index: usize) -> bool {
     (MIN_SIGNERS..=MAX_SIGNERS).contains(&index)
 }

--- a/token/program/src/native_mint.rs
+++ b/token/program/src/native_mint.rs
@@ -1,6 +1,6 @@
 //! The Mint that represents the native token
 
-/// There are 10^9 lamports in one SOL
+/// There are `10^9` lamports in one SOL
 pub const DECIMALS: u8 = 9;
 
 // The Mint for native SOL Token accounts

--- a/token/program/src/processor.rs
+++ b/token/program/src/processor.rs
@@ -61,7 +61,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeMint](enum.TokenInstruction.html) instruction.
+    /// Processes an [`InitializeMint`](enum.TokenInstruction.html) instruction.
     pub fn process_initialize_mint(
         accounts: &[AccountInfo],
         decimals: u8,
@@ -71,7 +71,8 @@ impl Processor {
         Self::_process_initialize_mint(accounts, decimals, mint_authority, freeze_authority, true)
     }
 
-    /// Processes an [InitializeMint2](enum.TokenInstruction.html) instruction.
+    /// Processes an [`InitializeMint2`](enum.TokenInstruction.html)
+    /// instruction.
     pub fn process_initialize_mint2(
         accounts: &[AccountInfo],
         decimals: u8,
@@ -141,7 +142,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeAccount](enum.TokenInstruction.html)
+    /// Processes an [`InitializeAccount`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_account(
         program_id: &Pubkey,
@@ -150,7 +151,7 @@ impl Processor {
         Self::_process_initialize_account(program_id, accounts, None, true)
     }
 
-    /// Processes an [InitializeAccount2](enum.TokenInstruction.html)
+    /// Processes an [`InitializeAccount2`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_account2(
         program_id: &Pubkey,
@@ -160,7 +161,7 @@ impl Processor {
         Self::_process_initialize_account(program_id, accounts, Some(&owner), true)
     }
 
-    /// Processes an [InitializeAccount3](enum.TokenInstruction.html)
+    /// Processes an [`InitializeAccount3`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_account3(
         program_id: &Pubkey,
@@ -212,19 +213,19 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [InitializeMultisig](enum.TokenInstruction.html)
+    /// Processes a [`InitializeMultisig`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_multisig(accounts: &[AccountInfo], m: u8) -> ProgramResult {
         Self::_process_initialize_multisig(accounts, m, true)
     }
 
-    /// Processes a [InitializeMultisig2](enum.TokenInstruction.html)
+    /// Processes a [`InitializeMultisig2`](enum.TokenInstruction.html)
     /// instruction.
     pub fn process_initialize_multisig2(accounts: &[AccountInfo], m: u8) -> ProgramResult {
         Self::_process_initialize_multisig(accounts, m, false)
     }
 
-    /// Processes a [Transfer](enum.TokenInstruction.html) instruction.
+    /// Processes a [`Transfer`](enum.TokenInstruction.html) instruction.
     pub fn process_transfer(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -341,7 +342,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Approve](enum.TokenInstruction.html) instruction.
+    /// Processes an [`Approve`](enum.TokenInstruction.html) instruction.
     pub fn process_approve(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -392,7 +393,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Revoke](enum.TokenInstruction.html) instruction.
+    /// Processes an [`Revoke`](enum.TokenInstruction.html) instruction.
     pub fn process_revoke(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let source_account_info = next_account_info(account_info_iter)?;
@@ -420,7 +421,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [SetAuthority](enum.TokenInstruction.html) instruction.
+    /// Processes a [`SetAuthority`](enum.TokenInstruction.html) instruction.
     pub fn process_set_authority(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -518,7 +519,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [MintTo](enum.TokenInstruction.html) instruction.
+    /// Processes a [`MintTo`](enum.TokenInstruction.html) instruction.
     pub fn process_mint_to(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -583,7 +584,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [Burn](enum.TokenInstruction.html) instruction.
+    /// Processes a [`Burn`](enum.TokenInstruction.html) instruction.
     pub fn process_burn(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -668,7 +669,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [CloseAccount](enum.TokenInstruction.html) instruction.
+    /// Processes a [`CloseAccount`](enum.TokenInstruction.html) instruction.
     pub fn process_close_account(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let source_account_info = next_account_info(account_info_iter)?;
@@ -709,8 +710,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [FreezeAccount](enum.TokenInstruction.html) or a
-    /// [ThawAccount](enum.TokenInstruction.html) instruction.
+    /// Processes a [`FreezeAccount`](enum.TokenInstruction.html) or a
+    /// [`ThawAccount`](enum.TokenInstruction.html) instruction.
     pub fn process_toggle_freeze_account(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -754,7 +755,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [SyncNative](enum.TokenInstruction.html) instruction
+    /// Processes a [`SyncNative`](enum.TokenInstruction.html) instruction
     pub fn process_sync_native(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
         let native_account_info = next_account_info(account_info_iter)?;
@@ -779,7 +780,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes a [GetAccountDataSize](enum.TokenInstruction.html) instruction
+    /// Processes a [`GetAccountDataSize`](enum.TokenInstruction.html)
+    /// instruction
     pub fn process_get_account_data_size(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -794,7 +796,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [InitializeImmutableOwner](enum.TokenInstruction.html)
+    /// Processes an [`InitializeImmutableOwner`](enum.TokenInstruction.html)
     /// instruction
     pub fn process_initialize_immutable_owner(accounts: &[AccountInfo]) -> ProgramResult {
         let account_info_iter = &mut accounts.iter();
@@ -807,7 +809,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [AmountToUiAmount](enum.TokenInstruction.html) instruction
+    /// Processes an [`AmountToUiAmount`](enum.TokenInstruction.html)
+    /// instruction
     pub fn process_amount_to_ui_amount(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -825,7 +828,8 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [AmountToUiAmount](enum.TokenInstruction.html) instruction
+    /// Processes an [`AmountToUiAmount`](enum.TokenInstruction.html)
+    /// instruction
     pub fn process_ui_amount_to_amount(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -843,7 +847,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Processes an [Instruction](enum.Instruction.html).
+    /// Processes an [`Instruction`](enum.Instruction.html).
     pub fn process(program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
         let instruction = TokenInstruction::unpack(input)?;
 

--- a/token/program/src/state.rs
+++ b/token/program/src/state.rs
@@ -98,7 +98,7 @@ pub struct Account {
     pub delegate: COption<Pubkey>,
     /// The account's state
     pub state: AccountState,
-    /// If is_native.is_some, this is a native token, and the value logs the
+    /// If `is_native.is_some`, this is a native token, and the value logs the
     /// rent-exempt reserve. An Account is required to be rent-exempt, so
     /// the value is used by the Processor to ensure that wrapped SOL
     /// accounts do not drop below this threshold.
@@ -117,7 +117,7 @@ impl Account {
     pub fn is_native(&self) -> bool {
         self.is_native.is_some()
     }
-    /// Checks if a token Account's owner is the system_program or the
+    /// Checks if a token Account's owner is the `system_program` or the
     /// incinerator
     pub fn is_owned_by_system_program_or_incinerator(&self) -> bool {
         solana_program::system_program::check_id(&self.owner)
@@ -344,7 +344,7 @@ pub trait GenericTokenAccount {
 pub const ACCOUNT_INITIALIZED_INDEX: usize = 108;
 
 /// Check if the account data buffer represents an initialized account.
-/// This is checking the `state` (AccountState) field of an Account object.
+/// This is checking the `state` (`AccountState`) field of an Account object.
 pub fn is_initialized_account(account_data: &[u8]) -> bool {
     *account_data
         .get(ACCOUNT_INITIALIZED_INDEX)

--- a/token/transfer-hook/example/README.md
+++ b/token/transfer-hook/example/README.md
@@ -10,7 +10,7 @@ code for more information.
 ### Example usage of example
 
 When testing your program that uses `spl-transfer-hook-interface`, you can also
-import this crate, and then use it with `solana-program-test`, ie:
+import this crate, and then use it with `solana-program-test`:
 
 ```rust
 use {

--- a/token/transfer-hook/example/src/processor.rs
+++ b/token/transfer-hook/example/src/processor.rs
@@ -74,7 +74,7 @@ pub fn process_execute(
 }
 
 /// Processes a
-/// [InitializeExtraAccountMetaList](enum.TransferHookInstruction.html)
+/// [`InitializeExtraAccountMetaList`](enum.TransferHookInstruction.html)
 /// instruction.
 pub fn process_initialize_extra_account_meta_list(
     program_id: &Pubkey,
@@ -142,7 +142,7 @@ pub fn process_initialize_extra_account_meta_list(
 }
 
 /// Processes a
-/// [UpdateExtraAccountMetaList](enum.TransferHookInstruction.html)
+/// [`UpdateExtraAccountMetaList`](enum.TransferHookInstruction.html)
 /// instruction.
 pub fn process_update_extra_account_meta_list(
     program_id: &Pubkey,

--- a/token/transfer-hook/interface/README.md
+++ b/token/transfer-hook/interface/README.md
@@ -86,7 +86,7 @@ Developers must implement the `Execute` instruction, and optionally the
 pubkeys into the program-derived address defined by the mint and program id.
 
 Note: it's technically not required to implement `InitializeExtraAccountMetaList`
-at that instruction descriminator. Your program may implement multiple interfaces,
+at that instruction discriminator. Your program may implement multiple interfaces,
 so any other instruction in your program can create the account at the program-derived
 address!
 
@@ -98,7 +98,7 @@ automatically resolved!
 
 ### Account Resolution
 
-Implementers of the transfer-hook interface are encouraged to make use of the
+Implementations of the transfer-hook interface are encouraged to make use of the
 [spl-tlv-account-resolution](https://github.com/solana-labs/solana-program-library/tree/master/libraries/tlv-account-resolution/README.md)
 library to manage the additional required accounts for their transfer hook
 program.

--- a/token/transfer-hook/interface/src/instruction.rs
+++ b/token/transfer-hook/interface/src/instruction.rs
@@ -25,8 +25,8 @@ pub enum TransferHookInstruction {
     ///   2. `[]` Destination account
     ///   3. `[]` Source account's owner/delegate
     ///   4. `[]` (Optional) Validation account
-    ///   5. ..5+M `[]` `M` optional additional accounts, written in validation
-    ///      account data
+    ///   5. ..`5+M` `[]` `M` optional additional accounts, written in
+    ///      validation account data
     Execute {
         /// Amount of tokens to transfer
         amount: u64,
@@ -80,7 +80,7 @@ pub struct UpdateExtraAccountMetaListInstruction;
 
 impl TransferHookInstruction {
     /// Unpacks a byte buffer into a
-    /// [TransferHookInstruction](enum.TransferHookInstruction.html).
+    /// [`TransferHookInstruction`](enum.TransferHookInstruction.html).
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
         if input.len() < ArrayDiscriminator::LENGTH {
             return Err(ProgramError::InvalidInstructionData);
@@ -113,8 +113,8 @@ impl TransferHookInstruction {
         })
     }
 
-    /// Packs a [TokenInstruction](enum.TokenInstruction.html) into a byte
-    /// buffer.
+    /// Packs a [`TransferHookInstruction`](enum.TransferHookInstruction.html)
+    /// into a byte buffer.
     pub fn pack(&self) -> Vec<u8> {
         let mut buf = vec![];
         match self {


### PR DESCRIPTION
#### Problem

There are typos in the token code, and people sometimes fix them, but mostly don't.

#### Summary of changes

Starting with the `token/*` directory, fix all typos or properly put them between backticks if they're code.

These were all found using `cargo spellcheck` and a specialized dictionary with programming / Solana / ZK terminology. Once all of the typos are fixed, then we can add the spellchecking to CI.