### PR TITLE
stake-pool: Downgrade dependencies for fixed release

### DIFF
--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "2.0.0"
+version = "2.0.1"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -20,12 +20,12 @@ num-traits = "0.2"
 num_enum = "0.7.3"
 serde = "1.0.215"
 serde_derive = "1.0.103"
-solana-program = "2.1.0"
+solana-program = "2.0.0"
 solana-security-txt = "1.1.1"
-spl-pod = { version = "0.5.0", path = "../../libraries/pod", features = [
+spl-pod = { version = "0.3.0", features = [
   "borsh",
 ] }
-spl-token-2022 = { version = "6.0.0", path = "../../token/program-2022", features = [
+spl-token-2022 = { version = "4.0.0", features = [
   "no-entrypoint",
 ] }
 thiserror = "2.0"
@@ -34,16 +34,13 @@ bincode = "1.3.1"
 [dev-dependencies]
 assert_matches = "1.5.0"
 proptest = "1.5"
-solana-program-test = "2.1.0"
-solana-sdk = "2.1.0"
-solana-vote-program = "2.1.0"
-spl-token = { version = "7.0", path = "../../token/program", features = [
+solana-program-test = "2.0.0"
+solana-sdk = "2.0.0"
+solana-vote-program = "2.0.0"
+spl-token = { version = "6.0", features = [
   "no-entrypoint",
 ] }
 test-case = "3.3"
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[lints]
-workspace = true


### PR DESCRIPTION
#### Problem

The current spl-stake-pool crate doesn't always work due to its dependency on spl-math which still uses the v1 Solana crates.

#### Summary of changes

Since the spl-math dependency wasn't actually needed, it was removed in #7421. So just to get a new patch release out, downgrade the local dependencies.

This will fail CI, but after it lands we can tag the release, and revert this PR.

cc @billythedummy 