### PR TITLE
Revert "stake-pool: Downgrade dependencies for fixed release (#7509)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8373,7 +8373,7 @@ dependencies = [
 
 [[package]]
 name = "spl-stake-pool"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "arrayref",
  "assert_matches",

--- a/stake-pool/cli/Cargo.toml
+++ b/stake-pool/cli/Cargo.toml
@@ -27,7 +27,7 @@ spl-associated-token-account = { version = "=6.0.0", path = "../../associated-to
   "no-entrypoint",
 ] }
 spl-associated-token-account-client = { version = "=2.0.0", path = "../../associated-token-account/client" }
-spl-stake-pool = { version = "=2.0.0", path = "../program", features = [
+spl-stake-pool = { version = "=2.0.1", path = "../program", features = [
   "no-entrypoint",
 ] }
 spl-token = { version = "=7.0", path = "../../token/program", features = [

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "2.0.0"
+version = "2.0.1"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"

--- a/stake-pool/program/Cargo.toml
+++ b/stake-pool/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-stake-pool"
-version = "2.0.1"
+version = "2.0.0"
 description = "Solana Program Library Stake Pool"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
@@ -20,12 +20,12 @@ num-traits = "0.2"
 num_enum = "0.7.3"
 serde = "1.0.215"
 serde_derive = "1.0.103"
-solana-program = "2.0.0"
+solana-program = "2.1.0"
 solana-security-txt = "1.1.1"
-spl-pod = { version = "0.3.0", features = [
+spl-pod = { version = "0.5.0", path = "../../libraries/pod", features = [
   "borsh",
 ] }
-spl-token-2022 = { version = "4.0.0", features = [
+spl-token-2022 = { version = "6.0.0", path = "../../token/program-2022", features = [
   "no-entrypoint",
 ] }
 thiserror = "2.0"
@@ -34,13 +34,16 @@ bincode = "1.3.1"
 [dev-dependencies]
 assert_matches = "1.5.0"
 proptest = "1.5"
-solana-program-test = "2.0.0"
-solana-sdk = "2.0.0"
-solana-vote-program = "2.0.0"
-spl-token = { version = "6.0", features = [
+solana-program-test = "2.1.0"
+solana-sdk = "2.1.0"
+solana-vote-program = "2.1.0"
+spl-token = { version = "7.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 test-case = "3.3"
 
 [lib]
 crate-type = ["cdylib", "lib"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
This reverts commit d4c250f34ab2b3ce9717c587da80fe20366ca605.

See #7509 for more info.

Reverts the commit, but still keeps the crate version at 2.0.1