### PR TITLE
token-2022: Add scaled amount extension

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -191,7 +191,7 @@ pub enum ExtensionInitializationParams {
     },
     ScaledUiAmountConfig {
         authority: Option<Pubkey>,
-        scale: f64,
+        multiplier: f64,
     },
 }
 impl ExtensionInitializationParams {
@@ -322,9 +322,15 @@ impl ExtensionInitializationParams {
                 authority,
                 member_address,
             ),
-            Self::ScaledUiAmountConfig { authority, scale } => {
-                scaled_ui_amount::instruction::initialize(token_program_id, mint, authority, scale)
-            }
+            Self::ScaledUiAmountConfig {
+                authority,
+                multiplier,
+            } => scaled_ui_amount::instruction::initialize(
+                token_program_id,
+                mint,
+                authority,
+                multiplier,
+            ),
         }
     }
 }
@@ -1814,23 +1820,25 @@ where
         .await
     }
 
-    /// Update scale
-    pub async fn update_scale<S: Signers>(
+    /// Update multiplier
+    pub async fn update_multiplier<S: Signers>(
         &self,
         authority: &Pubkey,
-        new_scale: f64,
+        new_multiplier: f64,
+        new_multiplier_effective_timestamp: i64,
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
         let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
 
         self.process_ixs(
-            &[scaled_ui_amount::instruction::update_scale(
+            &[scaled_ui_amount::instruction::update_multiplier(
                 &self.program_id,
                 self.get_address(),
                 authority,
                 &multisig_signers,
-                new_scale,
+                new_multiplier,
+                new_multiplier_effective_timestamp,
             )?],
             signing_keypairs,
         )

--- a/token/program-2022-test/tests/scaled_ui_amount.rs
+++ b/token/program-2022-test/tests/scaled_ui_amount.rs
@@ -1,0 +1,290 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{keypair_clone, TestContext, TokenContext},
+    solana_program_test::{
+        processor,
+        tokio::{self, sync::Mutex},
+        ProgramTest,
+    },
+    solana_sdk::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        instruction::{AccountMeta, Instruction, InstructionError},
+        msg,
+        program::{get_return_data, invoke},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, TransactionError},
+        transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{scaled_ui_amount::ScaledUiAmountConfig, BaseStateWithExtensions},
+        instruction::{amount_to_ui_amount, ui_amount_to_amount, AuthorityType},
+        processor::Processor,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::{convert::TryInto, sync::Arc},
+};
+
+#[tokio::test]
+async fn success_initialize() {
+    for (scale, authority) in [
+        (f64::MIN_POSITIVE, None),
+        (f64::MAX, Some(Pubkey::new_unique())),
+    ] {
+        let mut context = TestContext::new().await;
+        context
+            .init_token_with_mint(vec![ExtensionInitializationParams::ScaledUiAmountConfig {
+                authority,
+                scale,
+            }])
+            .await
+            .unwrap();
+        let TokenContext { token, .. } = context.token_context.unwrap();
+
+        let state = token.get_mint_info().await.unwrap();
+        let extension = state.get_extension::<ScaledUiAmountConfig>().unwrap();
+        assert_eq!(Option::<Pubkey>::from(extension.authority), authority,);
+        assert_eq!(f64::from(extension.scale), scale);
+    }
+}
+
+#[tokio::test]
+async fn update_scale() {
+    let authority = Keypair::new();
+    let initial_scale = 5.0;
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::ScaledUiAmountConfig {
+            authority: Some(authority.pubkey()),
+            scale: initial_scale,
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, .. } = context.token_context.take().unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<ScaledUiAmountConfig>().unwrap();
+    assert_eq!(f64::from(extension.scale), initial_scale);
+
+    // correct
+    let new_scale = 10.0;
+    token
+        .update_scale(&authority.pubkey(), new_scale, &[&authority])
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<ScaledUiAmountConfig>().unwrap();
+    assert_eq!(f64::from(extension.scale), new_scale);
+
+    // wrong signer
+    let wrong_signer = Keypair::new();
+    let err = token
+        .update_scale(&wrong_signer.pubkey(), 1.0, &[&wrong_signer])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn set_authority() {
+    let authority = Keypair::new();
+    let initial_scale = 500.0;
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::ScaledUiAmountConfig {
+            authority: Some(authority.pubkey()),
+            scale: initial_scale,
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, .. } = context.token_context.take().unwrap();
+
+    // success
+    let new_authority = Keypair::new();
+    token
+        .set_authority(
+            token.get_address(),
+            &authority.pubkey(),
+            Some(&new_authority.pubkey()),
+            AuthorityType::ScaledUiAmount,
+            &[&authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<ScaledUiAmountConfig>().unwrap();
+    assert_eq!(
+        extension.authority,
+        Some(new_authority.pubkey()).try_into().unwrap(),
+    );
+    token
+        .update_scale(&new_authority.pubkey(), 10.0, &[&new_authority])
+        .await
+        .unwrap();
+    let err = token
+        .update_scale(&authority.pubkey(), 100.0, &[&authority])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // set to none
+    token
+        .set_authority(
+            token.get_address(),
+            &new_authority.pubkey(),
+            None,
+            AuthorityType::ScaledUiAmount,
+            &[&new_authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<ScaledUiAmountConfig>().unwrap();
+    assert_eq!(extension.authority, None.try_into().unwrap(),);
+
+    // now all fail
+    let err = token
+        .update_scale(&new_authority.pubkey(), 50.0, &[&new_authority])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoAuthorityExists as u32)
+            )
+        )))
+    );
+    let err = token
+        .update_scale(&authority.pubkey(), 5.5, &[&authority])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::NoAuthorityExists as u32)
+            )
+        )))
+    );
+}
+
+// test program to CPI into token to get ui amounts
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _input: &[u8],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_info = next_account_info(account_info_iter)?;
+    let token_program = next_account_info(account_info_iter)?;
+    // 10 tokens, with 9 decimal places
+    let test_amount = 10_000_000_000;
+    // "10" as an amount should be smaller than test_amount due to interest
+    invoke(
+        &ui_amount_to_amount(token_program.key, mint_info.key, "50")?,
+        &[mint_info.clone(), token_program.clone()],
+    )?;
+    let (_, return_data) = get_return_data().unwrap();
+    let amount = u64::from_le_bytes(return_data[0..8].try_into().unwrap());
+    msg!("amount: {}", amount);
+    if amount != test_amount {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    // test_amount as a UI amount should be larger due to interest
+    invoke(
+        &amount_to_ui_amount(token_program.key, mint_info.key, test_amount)?,
+        &[mint_info.clone(), token_program.clone()],
+    )?;
+    let (_, return_data) = get_return_data().unwrap();
+    let ui_amount = String::from_utf8(return_data).unwrap();
+    msg!("ui amount: {}", ui_amount);
+    let float_ui_amount = ui_amount.parse::<f64>().unwrap();
+    if float_ui_amount != 50.0 {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn amount_conversions() {
+    let authority = Keypair::new();
+    let mut program_test = ProgramTest::default();
+    program_test.prefer_bpf(false);
+    program_test.add_program(
+        "spl_token_2022",
+        spl_token_2022::id(),
+        processor!(Processor::process),
+    );
+    let program_id = Pubkey::new_unique();
+    program_test.add_program(
+        "ui_amount_to_amount",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let context = program_test.start_with_context().await;
+    let payer = keypair_clone(&context.payer);
+    let last_blockhash = context.last_blockhash;
+    let context = Arc::new(Mutex::new(context));
+    let mut context = TestContext {
+        context,
+        token_context: None,
+    };
+    let initial_scale = 5.0;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::ScaledUiAmountConfig {
+            authority: Some(authority.pubkey()),
+            scale: initial_scale,
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, .. } = context.token_context.take().unwrap();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction {
+            program_id,
+            accounts: vec![
+                AccountMeta::new_readonly(*token.get_address(), false),
+                AccountMeta::new_readonly(spl_token_2022::id(), false),
+            ],
+            data: vec![],
+        }],
+        Some(&payer.pubkey()),
+        &[&payer],
+        last_blockhash,
+    );
+    context
+        .context
+        .lock()
+        .await
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -263,6 +263,9 @@ pub enum TokenError {
     /// Withdraw / Deposit not allowed for confidential-mint-burn
     #[error("Withdraw / Deposit not allowed for confidential-mint-burn")]
     IllegalMintBurnConversion,
+    /// Invalid scale for scaled ui amount
+    #[error("Invalid scale for scaled ui amount")]
+    InvalidScale,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -452,6 +455,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::IllegalMintBurnConversion => {
                 msg!("Conversions from normal to confidential token balance and vice versa are illegal if the confidential-mint-burn extension is enabled")
+            }
+            TokenError::InvalidScale => {
+                msg!("Invalid scale for scaled ui amount")
             }
         }
     }

--- a/token/program-2022/src/extension/scaled_ui_amount/instruction.rs
+++ b/token/program-2022/src/extension/scaled_ui_amount/instruction.rs
@@ -28,7 +28,8 @@ pub enum ScaledUiAmountMintInstruction {
     /// Fails if the mint has already been initialized, so must be called before
     /// `InitializeMint`.
     ///
-    /// Fails with any number less than 0.
+    /// Fails if the multiplier is less than or equal to 0 or if it's
+    /// [subnormal](https://en.wikipedia.org/wiki/Subnormal_number).
     ///
     /// The mint must have exactly enough space allocated for the base mint (82
     /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
@@ -43,6 +44,9 @@ pub enum ScaledUiAmountMintInstruction {
     Initialize,
     /// Update the multiplier. Only supported for mints that include the
     /// `ScaledUiAmount` extension.
+    ///
+    /// Fails if the multiplier is less than or equal to 0 or if it's
+    /// [subnormal](https://en.wikipedia.org/wiki/Subnormal_number).
     ///
     /// The authority provides a new multiplier and a unix timestamp on which
     /// it should take effect. If the timestamp is before the current time,

--- a/token/program-2022/src/extension/scaled_ui_amount/instruction.rs
+++ b/token/program-2022/src/extension/scaled_ui_amount/instruction.rs
@@ -1,0 +1,119 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+use {
+    crate::{
+        check_program_account,
+        extension::scaled_ui_amount::PodF64,
+        instruction::{encode_instruction, TokenInstruction},
+    },
+    bytemuck::{Pod, Zeroable},
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+    std::convert::TryInto,
+};
+
+/// Interesting-bearing mint extension instructions
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ScaledUiAmountMintInstruction {
+    /// Initialize a new mint with scaled UI amounts.
+    ///
+    /// Fails if the mint has already been initialized, so must be called before
+    /// `InitializeMint`.
+    ///
+    /// Fails with any number less than 0.
+    ///
+    /// The mint must have exactly enough space allocated for the base mint (82
+    /// bytes), plus 83 bytes of padding, 1 byte reserved for the account type,
+    /// then space required for this extension, plus any others.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to initialize.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::scaled_ui_amount::instruction::InitializeInstructionData`
+    Initialize,
+    /// Update the scale. Only supported for mints that include the
+    /// `ScaledUiAmount` extension.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[signer]` The mint scale authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The mint.
+    ///   1. `[]` The mint's multisignature scale authority.
+    ///   2. `..2+M` `[signer]` M signer accounts.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::scaled_ui_amount::PodF64`
+    UpdateScale,
+}
+
+/// Data expected by `ScaledUiAmountMint::Initialize`
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct InitializeInstructionData {
+    /// The public key for the account that can update the scale
+    pub authority: OptionalNonZeroPubkey,
+    /// The initial scale
+    pub scale: PodF64,
+}
+
+/// Create an `Initialize` instruction
+pub fn initialize(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: Option<Pubkey>,
+    scale: f64,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let accounts = vec![AccountMeta::new(*mint, false)];
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::ScaledUiAmountExtension,
+        ScaledUiAmountMintInstruction::Initialize,
+        &InitializeInstructionData {
+            authority: authority.try_into()?,
+            scale: scale.into(),
+        },
+    ))
+}
+
+/// Create an `UpdateScale` instruction
+pub fn update_scale(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
+    scale: f64,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::ScaledUiAmountExtension,
+        ScaledUiAmountMintInstruction::UpdateScale,
+        &PodF64::from(scale),
+    ))
+}

--- a/token/program-2022/src/extension/scaled_ui_amount/mod.rs
+++ b/token/program-2022/src/extension/scaled_ui_amount/mod.rs
@@ -64,7 +64,7 @@ impl ScaledUiAmountConfig {
     }
 
     /// Convert a raw amount to its UI representation using the given decimals
-    /// field Excess zeroes or unneeded decimal point are trimmed.
+    /// field. Excess zeroes or unneeded decimal point are trimmed.
     pub fn amount_to_ui_amount(
         &self,
         amount: u64,

--- a/token/program-2022/src/extension/scaled_ui_amount/mod.rs
+++ b/token/program-2022/src/extension/scaled_ui_amount/mod.rs
@@ -1,0 +1,271 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+use {
+    crate::extension::{Extension, ExtensionType},
+    bytemuck::{Pod, Zeroable},
+    solana_program::program_error::ProgramError,
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+};
+
+/// Scaled UI amount extension instructions
+pub mod instruction;
+
+/// Scaled UI amount extension processor
+pub mod processor;
+
+/// `f64` type that can be used in `Pod`s
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(from = "f64", into = "f64"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PodF64(pub [u8; 8]);
+impl PodF64 {
+    fn from_primitive(n: f64) -> Self {
+        Self(n.to_le_bytes())
+    }
+}
+impl From<f64> for PodF64 {
+    fn from(n: f64) -> Self {
+        Self::from_primitive(n)
+    }
+}
+impl From<PodF64> for f64 {
+    fn from(pod: PodF64) -> Self {
+        Self::from_le_bytes(pod.0)
+    }
+}
+
+/// Scaled UI amount extension data for mints
+#[repr(C)]
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct ScaledUiAmountConfig {
+    /// Authority that can set the scaling amount and authority
+    pub authority: OptionalNonZeroPubkey,
+    /// Amount to multiply raw amounts by, outside of the decimal
+    pub scale: PodF64,
+}
+impl ScaledUiAmountConfig {
+    fn total_scale(&self, decimals: u8) -> f64 {
+        f64::from(self.scale) / 10_f64.powi(decimals as i32)
+    }
+
+    /// Convert a raw amount to its UI representation using the given decimals
+    /// field Excess zeroes or unneeded decimal point are trimmed.
+    pub fn amount_to_ui_amount(&self, amount: u64, decimals: u8) -> Option<String> {
+        let scaled_amount = (amount as f64) * self.total_scale(decimals);
+        Some(scaled_amount.to_string())
+    }
+
+    /// Try to convert a UI representation of a token amount to its raw amount
+    /// using the given decimals field
+    pub fn try_ui_amount_into_amount(
+        &self,
+        ui_amount: &str,
+        decimals: u8,
+    ) -> Result<u64, ProgramError> {
+        let scaled_amount = ui_amount
+            .parse::<f64>()
+            .map_err(|_| ProgramError::InvalidArgument)?;
+        let amount = scaled_amount / self.total_scale(decimals);
+        if amount > (u64::MAX as f64) || amount < (u64::MIN as f64) || amount.is_nan() {
+            Err(ProgramError::InvalidArgument)
+        } else {
+            // this is important, if you round earlier, you'll get wrong "inf"
+            // answers
+            Ok(amount.round() as u64)
+        }
+    }
+}
+impl Extension for ScaledUiAmountConfig {
+    const TYPE: ExtensionType = ExtensionType::ScaledUiAmount;
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, proptest::prelude::*};
+
+    const TEST_DECIMALS: u8 = 2;
+
+    #[test]
+    fn specific_amount_to_ui_amount() {
+        // 5x
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: PodF64::from(5.0),
+        };
+        let ui_amount = config.amount_to_ui_amount(1, 0).unwrap();
+        assert_eq!(ui_amount, "5");
+        // with 1 decimal place
+        let ui_amount = config.amount_to_ui_amount(1, 1).unwrap();
+        assert_eq!(ui_amount, "0.5");
+        // with 10 decimal places
+        let ui_amount = config.amount_to_ui_amount(1, 10).unwrap();
+        assert_eq!(ui_amount, "0.0000000005");
+
+        // huge amount with 10 decimal places
+        let ui_amount = config.amount_to_ui_amount(10_000_000_000, 10).unwrap();
+        assert_eq!(ui_amount, "5");
+
+        // huge values
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: PodF64::from(f64::MAX),
+        };
+        let ui_amount = config.amount_to_ui_amount(u64::MAX, 0).unwrap();
+        assert_eq!(ui_amount, "inf");
+    }
+
+    #[test]
+    fn specific_ui_amount_to_amount() {
+        // constant 5x
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: 5.0.into(),
+        };
+        let amount = config.try_ui_amount_into_amount("5.0", 0).unwrap();
+        assert_eq!(1, amount);
+        // with 1 decimal place
+        let amount = config.try_ui_amount_into_amount("0.500000000", 1).unwrap();
+        assert_eq!(amount, 1);
+        // with 10 decimal places
+        let amount = config
+            .try_ui_amount_into_amount("0.00000000050000000000000000", 10)
+            .unwrap();
+        assert_eq!(amount, 1);
+
+        // huge amount with 10 decimal places
+        let amount = config
+            .try_ui_amount_into_amount("5.0000000000000000", 10)
+            .unwrap();
+        assert_eq!(amount, 10_000_000_000);
+
+        // huge values
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: 5.0.into(),
+        };
+        let amount = config
+            .try_ui_amount_into_amount("92233720368547758075", 0)
+            .unwrap();
+        assert_eq!(amount, u64::MAX);
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: f64::MAX.into(),
+        };
+        // scientific notation "e"
+        let amount = config
+            .try_ui_amount_into_amount("1.7976931348623157e308", 0)
+            .unwrap();
+        assert_eq!(amount, 1);
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: 9.745314011399998e288.into(),
+        };
+        let amount = config
+            .try_ui_amount_into_amount("1.7976931348623157e308", 0)
+            .unwrap();
+        assert_eq!(amount, u64::MAX);
+        // scientific notation "E"
+        let amount = config
+            .try_ui_amount_into_amount("1.7976931348623157E308", 0)
+            .unwrap();
+        assert_eq!(amount, u64::MAX);
+
+        // this is unfortunate, but underflows can happen due to floats
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: 1.0.into(),
+        };
+        assert_eq!(
+            u64::MAX,
+            config
+                .try_ui_amount_into_amount("18446744073709551616", 0)
+                .unwrap() // u64::MAX + 1
+        );
+
+        // overflow u64 fail
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: 0.1.into(),
+        };
+        assert_eq!(
+            Err(ProgramError::InvalidArgument),
+            config.try_ui_amount_into_amount("18446744073709551615", 0) // u64::MAX + 1
+        );
+
+        for fail_ui_amount in ["-0.0000000000000000000001", "inf", "-inf", "NaN"] {
+            assert_eq!(
+                Err(ProgramError::InvalidArgument),
+                config.try_ui_amount_into_amount(fail_ui_amount, 0)
+            );
+        }
+    }
+
+    #[test]
+    fn specific_amount_to_ui_amount_no_scale() {
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: 1.0.into(),
+        };
+        for (amount, expected) in [(23, "0.23"), (110, "1.1"), (4200, "42"), (0, "0")] {
+            let ui_amount = config.amount_to_ui_amount(amount, TEST_DECIMALS).unwrap();
+            assert_eq!(ui_amount, expected);
+        }
+    }
+
+    #[test]
+    fn specific_ui_amount_to_amount_no_scale() {
+        let config = ScaledUiAmountConfig {
+            authority: OptionalNonZeroPubkey::default(),
+            scale: 1.0.into(),
+        };
+        for (ui_amount, expected) in [
+            ("0.23", 23),
+            ("0.20", 20),
+            ("0.2000", 20),
+            (".2", 20),
+            ("1.1", 110),
+            ("1.10", 110),
+            ("42", 4200),
+            ("42.", 4200),
+            ("0", 0),
+        ] {
+            let amount = config
+                .try_ui_amount_into_amount(ui_amount, TEST_DECIMALS)
+                .unwrap();
+            assert_eq!(expected, amount);
+        }
+
+        // this is invalid with normal mints, but rounding for this mint makes it ok
+        let amount = config
+            .try_ui_amount_into_amount("0.111", TEST_DECIMALS)
+            .unwrap();
+        assert_eq!(11, amount);
+
+        // fail if invalid ui_amount passed in
+        for ui_amount in ["", ".", "0.t"] {
+            assert_eq!(
+                Err(ProgramError::InvalidArgument),
+                config.try_ui_amount_into_amount(ui_amount, TEST_DECIMALS),
+            );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn amount_to_ui_amount(
+            scale in 0f64..=f64::MAX,
+            amount in 0..=u64::MAX,
+            decimals in 0u8..20u8,
+        ) {
+            let config = ScaledUiAmountConfig {
+                authority: OptionalNonZeroPubkey::default(),
+                scale: scale.into(),
+            };
+            let ui_amount = config.amount_to_ui_amount(amount, decimals);
+            assert!(ui_amount.is_some());
+        }
+    }
+}

--- a/token/program-2022/src/extension/scaled_ui_amount/processor.rs
+++ b/token/program-2022/src/extension/scaled_ui_amount/processor.rs
@@ -1,0 +1,99 @@
+use {
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{
+            scaled_ui_amount::{
+                instruction::{InitializeInstructionData, ScaledUiAmountMintInstruction},
+                PodF64, ScaledUiAmountConfig,
+            },
+            BaseStateWithExtensionsMut, PodStateWithExtensionsMut,
+        },
+        instruction::{decode_instruction_data, decode_instruction_type},
+        pod::PodMint,
+        processor::Processor,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        pubkey::Pubkey,
+    },
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
+};
+
+fn try_validate_scale(scale: &PodF64) -> ProgramResult {
+    let float_scale = f64::from(*scale);
+    if float_scale.is_sign_positive() && float_scale.is_normal() {
+        Ok(())
+    } else {
+        Err(TokenError::InvalidScale.into())
+    }
+}
+
+fn process_initialize(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    authority: &OptionalNonZeroPubkey,
+    scale: &PodF64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut mint_data)?;
+
+    let extension = mint.init_extension::<ScaledUiAmountConfig>(true)?;
+    extension.authority = *authority;
+    try_validate_scale(scale)?;
+    extension.scale = *scale;
+    Ok(())
+}
+
+fn process_update_scale(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_scale: &PodF64,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let owner_info = next_account_info(account_info_iter)?;
+    let owner_info_data_len = owner_info.data_len();
+
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
+    let extension = mint.get_extension_mut::<ScaledUiAmountConfig>()?;
+    let authority =
+        Option::<Pubkey>::from(extension.authority).ok_or(TokenError::NoAuthorityExists)?;
+
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        owner_info,
+        owner_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    try_validate_scale(new_scale)?;
+    extension.scale = *new_scale;
+    Ok(())
+}
+
+pub(crate) fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    check_program_account(program_id)?;
+    match decode_instruction_type(input)? {
+        ScaledUiAmountMintInstruction::Initialize => {
+            msg!("ScaledUiAmountMintInstruction::Initialize");
+            let InitializeInstructionData { authority, scale } = decode_instruction_data(input)?;
+            process_initialize(program_id, accounts, authority, scale)
+        }
+        ScaledUiAmountMintInstruction::UpdateScale => {
+            msg!("ScaledUiAmountMintInstruction::UpdateScale");
+            let new_scale = decode_instruction_data(input)?;
+            process_update_scale(program_id, accounts, new_scale)
+        }
+    }
+}

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -712,6 +712,9 @@ pub enum TokenInstruction<'a> {
     /// Instruction prefix for instructions to the confidential-mint-burn
     /// extension
     ConfidentialMintBurnExtension,
+    /// Instruction prefix for instructions to the scaled ui amount
+    /// extension
+    ScaledUiAmountExtension,
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a
@@ -852,6 +855,7 @@ impl<'a> TokenInstruction<'a> {
             40 => Self::GroupPointerExtension,
             41 => Self::GroupMemberPointerExtension,
             42 => Self::ConfidentialMintBurnExtension,
+            43 => Self::ScaledUiAmountExtension,
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -1026,6 +1030,9 @@ impl<'a> TokenInstruction<'a> {
             &Self::ConfidentialMintBurnExtension => {
                 buf.push(42);
             }
+            &Self::ScaledUiAmountExtension => {
+                buf.push(43);
+            }
         };
         buf
     }
@@ -1123,6 +1130,8 @@ pub enum AuthorityType {
     GroupPointer,
     /// Authority to set the group member address
     GroupMemberPointer,
+    /// Authority to set the UI amount scale
+    ScaledUiAmount,
 }
 
 impl AuthorityType {
@@ -1143,6 +1152,7 @@ impl AuthorityType {
             AuthorityType::MetadataPointer => 12,
             AuthorityType::GroupPointer => 13,
             AuthorityType::GroupMemberPointer => 14,
+            AuthorityType::ScaledUiAmount => 15,
         }
     }
 
@@ -1163,6 +1173,7 @@ impl AuthorityType {
             12 => Ok(AuthorityType::MetadataPointer),
             13 => Ok(AuthorityType::GroupPointer),
             14 => Ok(AuthorityType::GroupMemberPointer),
+            15 => Ok(AuthorityType::ScaledUiAmount),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/token/program-2022/src/pod_instruction.rs
+++ b/token/program-2022/src/pod_instruction.rs
@@ -115,6 +115,7 @@ pub(crate) enum PodTokenInstruction {
     GroupPointerExtension,
     GroupMemberPointerExtension,
     ConfidentialMintBurnExtension,
+    ScaledUiAmountExtension,
 }
 
 fn unpack_pubkey_option(input: &[u8]) -> Result<PodCOption<Pubkey>, ProgramError> {

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -1388,8 +1388,9 @@ impl Processor {
                 .amount_to_ui_amount(amount, mint.base.decimals, unix_timestamp)
                 .ok_or(ProgramError::InvalidArgument)?
         } else if let Ok(extension) = mint.get_extension::<ScaledUiAmountConfig>() {
+            let unix_timestamp = Clock::get()?.unix_timestamp;
             extension
-                .amount_to_ui_amount(amount, mint.base.decimals)
+                .amount_to_ui_amount(amount, mint.base.decimals, unix_timestamp)
                 .ok_or(ProgramError::InvalidArgument)?
         } else {
             crate::amount_to_ui_amount_string_trimmed(amount, mint.base.decimals)
@@ -1413,7 +1414,8 @@ impl Processor {
             let unix_timestamp = Clock::get()?.unix_timestamp;
             extension.try_ui_amount_into_amount(ui_amount, mint.base.decimals, unix_timestamp)?
         } else if let Ok(extension) = mint.get_extension::<ScaledUiAmountConfig>() {
-            extension.try_ui_amount_into_amount(ui_amount, mint.base.decimals)?
+            let unix_timestamp = Clock::get()?.unix_timestamp;
+            extension.try_ui_amount_into_amount(ui_amount, mint.base.decimals, unix_timestamp)?
         } else {
             crate::try_ui_amount_into_amount(ui_amount.to_string(), mint.base.decimals)?
         };

--- a/token/program-2022/src/processor.rs
+++ b/token/program-2022/src/processor.rs
@@ -21,7 +21,9 @@ use {
             mint_close_authority::MintCloseAuthority,
             non_transferable::{NonTransferable, NonTransferableAccount},
             permanent_delegate::{get_permanent_delegate, PermanentDelegate},
-            reallocate, token_group, token_metadata,
+            reallocate,
+            scaled_ui_amount::{self, ScaledUiAmountConfig},
+            token_group, token_metadata,
             transfer_fee::{self, TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{self, TransferHook, TransferHookAccount},
             AccountType, BaseStateWithExtensions, BaseStateWithExtensionsMut, ExtensionType,
@@ -906,6 +908,19 @@ impl Processor {
                     )?;
                     extension.authority = new_authority.try_into()?;
                 }
+                AuthorityType::ScaledUiAmount => {
+                    let extension = mint.get_extension_mut::<ScaledUiAmountConfig>()?;
+                    let maybe_authority: Option<Pubkey> = extension.authority.into();
+                    let authority = maybe_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
+                    Self::validate_owner(
+                        program_id,
+                        &authority,
+                        authority_info,
+                        authority_info_data_len,
+                        account_info_iter.as_slice(),
+                    )?;
+                    extension.authority = new_authority.try_into()?;
+                }
                 _ => {
                     return Err(TokenError::AuthorityTypeNotSupported.into());
                 }
@@ -1372,6 +1387,10 @@ impl Processor {
             extension
                 .amount_to_ui_amount(amount, mint.base.decimals, unix_timestamp)
                 .ok_or(ProgramError::InvalidArgument)?
+        } else if let Ok(extension) = mint.get_extension::<ScaledUiAmountConfig>() {
+            extension
+                .amount_to_ui_amount(amount, mint.base.decimals)
+                .ok_or(ProgramError::InvalidArgument)?
         } else {
             crate::amount_to_ui_amount_string_trimmed(amount, mint.base.decimals)
         };
@@ -1393,6 +1412,8 @@ impl Processor {
         let amount = if let Ok(extension) = mint.get_extension::<InterestBearingConfig>() {
             let unix_timestamp = Clock::get()?.unix_timestamp;
             extension.try_ui_amount_into_amount(ui_amount, mint.base.decimals, unix_timestamp)?
+        } else if let Ok(extension) = mint.get_extension::<ScaledUiAmountConfig>() {
+            extension.try_ui_amount_into_amount(ui_amount, mint.base.decimals)?
         } else {
             crate::try_ui_amount_into_amount(ui_amount.to_string(), mint.base.decimals)?
         };
@@ -1808,6 +1829,14 @@ impl Processor {
                 PodTokenInstruction::ConfidentialMintBurnExtension => {
                     msg!("Instruction: ConfidentialMintBurnExtension");
                     confidential_mint_burn::processor::process_instruction(
+                        program_id,
+                        accounts,
+                        &input[1..],
+                    )
+                }
+                PodTokenInstruction::ScaledUiAmountExtension => {
+                    msg!("Instruction: ScaledUiAmountExtension");
+                    scaled_ui_amount::processor::process_instruction(
                         program_id,
                         accounts,
                         &input[1..],


### PR DESCRIPTION
#### Problem

The interest-bearing extension is useful for tokens that accrue in value constantly, but many "rebasing" tokens on other blockchains employ a different method of updating the number of tokens in accounts.

Rather than setting a rate and allowing the number to change automatically over time, they set a scaling factor for the tokens by hand.

#### Summary of changes

Add a new `ScaledUiAmount` extension to token-2022 for doing just that. This is essentially a simplified version of the interest-bearing extension, where someone just sets a scaling value into the mint directly. The scale has no impact on the operation of the token, just on the output of `amount_to_ui_amount` and `ui_amount_to_amount`.

cc @jnwng