### PR TITLE
token-client: Check simulation results for error

### DIFF
--- a/token/client/src/token.rs
+++ b/token/client/src/token.rs
@@ -588,6 +588,9 @@ where
         let units_consumed = simulation_result
             .get_compute_units_consumed()
             .map_err(TokenError::Client)?;
+        if let Some(err) = simulation_result.err() {
+            return Err(TokenError::Client(err));
+        }
         // Overwrite the compute unit limit instruction with the actual units consumed
         let compute_unit_limit =
             u32::try_from(units_consumed).map_err(|x| TokenError::Client(x.into()))?;


### PR DESCRIPTION
#### Problem

If the simulation for compute unit limit fails in the token-cli, it may continue to try to broadcast a transaction since the error falls through. Although that transaction should fail too, at least we don't run the risk of broadcasting something known to be bad.

#### Summary of changes

Add an `err()` function on the simulation results, and abort if the simulation for compute units fails.