### PR TITLE
[token-cli] Fix panicking behavior from `sign_only`

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -106,7 +106,7 @@ impl<'a> Config<'a> {
             CommitmentConfig::confirmed(),
             DEFAULT_CONFIRM_TX_TIMEOUT,
         ));
-        let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
+        let sign_only = matches.try_contains_id(SIGN_ONLY_ARG.name).unwrap_or(false);
         let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> = if sign_only {
             let blockhash = matches
                 .get_one::<Hash>(BLOCKHASH_ARG.name)


### PR DESCRIPTION
#### Problem
In clap v2, the `ArgMatches::is_present(ARG_NAME)` function returns `None` when `ARG_NAME` is not defined in the clap app. In clap v3, `ArgMatches::is_present(ARG_NAME)` panics of `ARG_NAME` is not defined in the clap app.

I thought I fixed all occurrences of `is_present` that could panic in the token-cli, but it seems that I missed one place when we parse for `Config`.

```
`sign_only` is not an id of an argument or a group.
Make sure you're using the name of the argument itself and not the name of short or long flags.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

#### Summary of Changes
Replace `is_present` with `try_contains_id` that does not panic.