### PR TITLE
token-2022: Take decimals into account for UI amount

### DIFF
--- a/token/program-2022/src/extension/scaled_ui_amount/mod.rs
+++ b/token/program-2022/src/extension/scaled_ui_amount/mod.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "serde-traits")]
 use serde::{Deserialize, Serialize};
 use {
-    crate::extension::{Extension, ExtensionType},
+    crate::{
+        extension::{Extension, ExtensionType},
+        trim_ui_amount_string,
+    },
     bytemuck::{Pod, Zeroable},
     solana_program::program_error::ProgramError,
     spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodI64},
@@ -72,7 +75,8 @@ impl ScaledUiAmountConfig {
         unix_timestamp: i64,
     ) -> Option<String> {
         let scaled_amount = (amount as f64) * self.total_multiplier(decimals, unix_timestamp);
-        Some(scaled_amount.to_string())
+        let ui_amount = format!("{scaled_amount:.*}", decimals as usize);
+        Some(trim_ui_amount_string(ui_amount, decimals))
     }
 
     /// Try to convert a UI representation of a token amount to its raw amount

--- a/token/program-2022/src/lib.rs
+++ b/token/program-2022/src/lib.rs
@@ -62,12 +62,17 @@ pub fn amount_to_ui_amount_string(amount: u64, decimals: u8) -> String {
 /// Convert a raw amount to its UI representation using the given decimals field
 /// Excess zeroes or unneeded decimal point are trimmed.
 pub fn amount_to_ui_amount_string_trimmed(amount: u64, decimals: u8) -> String {
-    let mut s = amount_to_ui_amount_string(amount, decimals);
+    let s = amount_to_ui_amount_string(amount, decimals);
+    trim_ui_amount_string(s, decimals)
+}
+
+/// Trims a string number by removing excess zeroes or unneeded decimal point
+fn trim_ui_amount_string(mut ui_amount: String, decimals: u8) -> String {
     if decimals > 0 {
-        let zeros_trimmed = s.trim_end_matches('0');
-        s = zeros_trimmed.trim_end_matches('.').to_string();
+        let zeros_trimmed = ui_amount.trim_end_matches('0');
+        ui_amount = zeros_trimmed.trim_end_matches('.').to_string();
     }
-    s
+    ui_amount
 }
 
 /// Try to convert a UI representation of a token amount to its raw amount using


### PR DESCRIPTION
#### Problem

The interest-bearing and scaled UI amount extensions don't take into account the mint decimals when printing the number, and they don't properly trim afterwards. This can be confusing.

#### Summary of changes

Update the UI amount conversion to take into account the decimals of precision, and then actually trim. Note that a lot of calculations become more precise because of this change!