### PR TITLE
add allowOwnerOffCurve parameter to createAssociatedTokenAccountIdempotent

### DIFF
--- a/token/js/src/actions/createAssociatedTokenAccountIdempotent.ts
+++ b/token/js/src/actions/createAssociatedTokenAccountIdempotent.ts
@@ -15,6 +15,7 @@ import { getAssociatedTokenAddressSync } from '../state/mint.js';
  * @param confirmOptions           Options for confirming the transaction
  * @param programId                SPL Token program account
  * @param associatedTokenProgramId SPL Associated Token program account
+ * @param allowOwnerOffCurve       Allow the owner account to be a PDA (Program Derived Address)
  *
  * @return Address of the new or existing associated token account
  */
@@ -26,8 +27,15 @@ export async function createAssociatedTokenAccountIdempotent(
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
     associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
+    allowOwnerOffCurve = false,
 ): Promise<PublicKey> {
-    const associatedToken = getAssociatedTokenAddressSync(mint, owner, false, programId, associatedTokenProgramId);
+    const associatedToken = getAssociatedTokenAddressSync(
+        mint,
+        owner,
+        allowOwnerOffCurve,
+        programId,
+        associatedTokenProgramId,
+    );
 
     const transaction = new Transaction().add(
         createAssociatedTokenAccountIdempotentInstruction(


### PR DESCRIPTION
This add `allowOwnerOffCurve` parameter to `createAssociatedTokenAccountIdempotent`.  

The `createAssociatedTokenAccount` action has an option to allow off curve owner, but not in `createAssociatedTokenAccountIdempotent`.