### PR TITLE
token-2022: Add Pausable extension

### DIFF
--- a/token/program-2022-test/tests/pausable.rs
+++ b/token/program-2022-test/tests/pausable.rs
@@ -1,0 +1,356 @@
+#![cfg(feature = "test-sbf")]
+
+mod program_test;
+use {
+    program_test::{TestContext, TokenContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError, pubkey::Pubkey, signature::Signer, signer::keypair::Keypair,
+        transaction::TransactionError, transport::TransportError,
+    },
+    spl_token_2022::{
+        error::TokenError,
+        extension::{
+            pausable::{PausableAccount, PausableConfig},
+            BaseStateWithExtensions,
+        },
+        instruction::AuthorityType,
+    },
+    spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
+    std::convert::TryInto,
+};
+
+#[tokio::test]
+async fn success_initialize() {
+    let authority = Pubkey::new_unique();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PausableConfig {
+            authority,
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, alice, .. } = context.token_context.unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PausableConfig>().unwrap();
+    assert_eq!(Option::<Pubkey>::from(extension.authority), Some(authority));
+    assert!(!bool::from(extension.paused));
+
+    let account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&account, &alice.pubkey())
+        .await
+        .unwrap();
+    let state = token.get_account_info(&account.pubkey()).await.unwrap();
+    let _ = state.get_extension::<PausableAccount>().unwrap();
+}
+
+#[tokio::test]
+async fn set_authority() {
+    let authority = Keypair::new();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PausableConfig {
+            authority: authority.pubkey(),
+        }])
+        .await
+        .unwrap();
+    let TokenContext { token, .. } = context.token_context.take().unwrap();
+
+    // success
+    let new_authority = Keypair::new();
+    token
+        .set_authority(
+            token.get_address(),
+            &authority.pubkey(),
+            Some(&new_authority.pubkey()),
+            AuthorityType::Pause,
+            &[&authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PausableConfig>().unwrap();
+    assert_eq!(
+        extension.authority,
+        Some(new_authority.pubkey()).try_into().unwrap(),
+    );
+    token
+        .pause(&new_authority.pubkey(), &[&new_authority])
+        .await
+        .unwrap();
+    let err = token
+        .pause(&authority.pubkey(), &[&authority])
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::OwnerMismatch as u32)
+            )
+        )))
+    );
+
+    // set to none
+    token
+        .set_authority(
+            token.get_address(),
+            &new_authority.pubkey(),
+            None,
+            AuthorityType::Pause,
+            &[&new_authority],
+        )
+        .await
+        .unwrap();
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<PausableConfig>().unwrap();
+    assert_eq!(extension.authority, None.try_into().unwrap(),);
+}
+
+#[tokio::test]
+async fn pause_mint() {
+    let authority = Keypair::new();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PausableConfig {
+            authority: authority.pubkey(),
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        mint_authority,
+        token,
+        token_unchecked,
+        alice,
+        ..
+    } = context.token_context.take().unwrap();
+
+    let alice_account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+    let alice_account = alice_account.pubkey();
+
+    token
+        .pause(&authority.pubkey(), &[&authority])
+        .await
+        .unwrap();
+
+    let amount = 10;
+    let error = token
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            &[&mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintPaused as u32)
+            )
+        )))
+    );
+
+    let error = token_unchecked
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            &[&mint_authority],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintPaused as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn pause_burn() {
+    let authority = Keypair::new();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PausableConfig {
+            authority: authority.pubkey(),
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        mint_authority,
+        token,
+        token_unchecked,
+        alice,
+        ..
+    } = context.token_context.take().unwrap();
+
+    let alice_account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+    let alice_account = alice_account.pubkey();
+
+    let amount = 10;
+    token
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            &[&mint_authority],
+        )
+        .await
+        .unwrap();
+
+    token
+        .pause(&authority.pubkey(), &[&authority])
+        .await
+        .unwrap();
+
+    let error = token_unchecked
+        .burn(&alice_account, &alice.pubkey(), 1, &[&alice])
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintPaused as u32)
+            )
+        )))
+    );
+
+    let error = token
+        .burn(&alice_account, &alice.pubkey(), 1, &[&alice])
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintPaused as u32)
+            )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn pause_transfer() {
+    let authority = Keypair::new();
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![ExtensionInitializationParams::PausableConfig {
+            authority: authority.pubkey(),
+        }])
+        .await
+        .unwrap();
+    let TokenContext {
+        mint_authority,
+        token,
+        token_unchecked,
+        alice,
+        bob,
+        ..
+    } = context.token_context.take().unwrap();
+
+    let alice_account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&alice_account, &alice.pubkey())
+        .await
+        .unwrap();
+    let alice_account = alice_account.pubkey();
+
+    let bob_account = Keypair::new();
+    token
+        .create_auxiliary_token_account(&bob_account, &bob.pubkey())
+        .await
+        .unwrap();
+    let bob_account = bob_account.pubkey();
+
+    let amount = 10;
+    token
+        .mint_to(
+            &alice_account,
+            &mint_authority.pubkey(),
+            amount,
+            &[&mint_authority],
+        )
+        .await
+        .unwrap();
+
+    token
+        .pause(&authority.pubkey(), &[&authority])
+        .await
+        .unwrap();
+
+    let error = token_unchecked
+        .transfer(&alice_account, &bob_account, &alice.pubkey(), 1, &[&alice])
+        .await
+        .unwrap_err();
+
+    // need to use checked transfer
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintRequiredForTransfer as u32)
+            )
+        )))
+    );
+
+    let error = token
+        .transfer(&alice_account, &bob_account, &alice.pubkey(), 1, &[&alice])
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintPaused as u32)
+            )
+        )))
+    );
+
+    let error = token
+        .transfer_with_fee(
+            &alice_account,
+            &bob_account,
+            &alice.pubkey(),
+            1,
+            0,
+            &[&alice],
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(TokenError::MintPaused as u32)
+            )
+        )))
+    );
+}

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -266,6 +266,9 @@ pub enum TokenError {
     /// Invalid scale for scaled ui amount
     #[error("Invalid scale for scaled ui amount")]
     InvalidScale,
+    /// Transferring, minting, and burning is paused on this mint
+    #[error("Transferring, minting, and burning is paused on this mint")]
+    MintPaused,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -458,6 +461,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::InvalidScale => {
                 msg!("Invalid scale for scaled ui amount")
+            }
+            TokenError::MintPaused => {
+                msg!("Transferring, minting, and burning is paused on this mint");
             }
         }
     }

--- a/token/program-2022/src/error.rs
+++ b/token/program-2022/src/error.rs
@@ -463,7 +463,7 @@ impl PrintProgramError for TokenError {
                 msg!("Invalid scale for scaled ui amount")
             }
             TokenError::MintPaused => {
-                msg!("Transferring, minting, and burning is paused on this mint");
+                msg!("Transferring, minting, and burning is paused on this mint")
             }
         }
     }

--- a/token/program-2022/src/extension/confidential_mint_burn/processor.rs
+++ b/token/program-2022/src/extension/confidential_mint_burn/processor.rs
@@ -15,6 +15,7 @@ use {
                 ConfidentialMintBurn,
             },
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
+            pausable::PausableConfig,
             BaseStateWithExtensions, BaseStateWithExtensionsMut, PodStateWithExtensionsMut,
         },
         instruction::{decode_instruction_data, decode_instruction_type},
@@ -161,6 +162,11 @@ fn process_confidential_mint(
     let auditor_elgamal_pubkey = mint
         .get_extension::<ConfidentialTransferMint>()?
         .auditor_elgamal_pubkey;
+    if let Ok(extension) = mint.get_extension::<PausableConfig>() {
+        if extension.paused.into() {
+            return Err(TokenError::MintPaused.into());
+        }
+    }
     let mint_burn_extension = mint.get_extension_mut::<ConfidentialMintBurn>()?;
 
     let proof_context = verify_mint_proof(
@@ -285,6 +291,11 @@ fn process_confidential_burn(
     let auditor_elgamal_pubkey = mint
         .get_extension::<ConfidentialTransferMint>()?
         .auditor_elgamal_pubkey;
+    if let Ok(extension) = mint.get_extension::<PausableConfig>() {
+        if extension.paused.into() {
+            return Err(TokenError::MintPaused.into());
+        }
+    }
     let mint_burn_extension = mint.get_extension_mut::<ConfidentialMintBurn>()?;
 
     let proof_context = verify_burn_proof(

--- a/token/program-2022/src/extension/confidential_transfer/instruction.rs
+++ b/token/program-2022/src/extension/confidential_transfer/instruction.rs
@@ -183,6 +183,7 @@ pub enum ConfidentialTransferInstruction {
     /// Fails if the source or destination accounts are frozen.
     /// Fails if the associated mint is extended as `NonTransferable`.
     /// Fails if the associated mint is extended as `ConfidentialMintBurn`.
+    /// Fails if the associated mint is paused with the `Pausable` extension.
     ///
     /// Accounts expected by this instruction:
     ///
@@ -219,6 +220,7 @@ pub enum ConfidentialTransferInstruction {
     /// Fails if the source or destination accounts are frozen.
     /// Fails if the associated mint is extended as `NonTransferable`.
     /// Fails if the associated mint is extended as `ConfidentialMintBurn`.
+    /// Fails if the associated mint is paused with the `Pausable` extension.
     ///
     /// Accounts expected by this instruction:
     ///

--- a/token/program-2022/src/extension/pausable/instruction.rs
+++ b/token/program-2022/src/extension/pausable/instruction.rs
@@ -1,0 +1,136 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+use {
+    crate::{
+        check_program_account,
+        instruction::{encode_instruction, TokenInstruction},
+    },
+    bytemuck::{Pod, Zeroable},
+    num_enum::{IntoPrimitive, TryFromPrimitive},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+};
+
+/// Pausable extension instructions
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
+pub enum PausableInstruction {
+    /// Initialize the pausable extension for the given mint account
+    ///
+    /// Fails if the account has already been initialized, so must be called
+    /// before `InitializeMint`.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]`  The mint account to initialize.
+    ///
+    /// Data expected by this instruction:
+    ///   `crate::extension::pausable::instruction::InitializeInstructionData`
+    Initialize,
+    /// Pause minting, burning, and transferring for the mint.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to update.
+    ///   1. `[signer]` The mint's pause authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The mint to update.
+    ///   1. `[]` The mint's multisignature pause authority.
+    ///   2. `..2+M` `[signer]` M signer accounts.
+    Pause,
+    /// Resume minting, burning, and transferring for the mint.
+    ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   0. `[writable]` The mint to update.
+    ///   1. `[signer]` The mint's pause authority.
+    ///
+    ///   * Multisignature authority
+    ///   0. `[writable]` The mint to update.
+    ///   1. `[]` The mint's multisignature pause authority.
+    ///   2. `..2+M` `[signer]` M signer accounts.
+    Resume,
+}
+
+/// Data expected by `PausableInstruction::Initialize`
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+pub struct InitializeInstructionData {
+    /// The public key for the account that can pause the mint
+    pub authority: Pubkey,
+}
+
+/// Create an `Initialize` instruction
+pub fn initialize(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let accounts = vec![AccountMeta::new(*mint, false)];
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::PausableExtension,
+        PausableInstruction::Initialize,
+        &InitializeInstructionData {
+            authority: *authority,
+        },
+    ))
+}
+
+/// Create a `Pause` instruction
+pub fn pause(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::PausableExtension,
+        PausableInstruction::Pause,
+        &(),
+    ))
+}
+
+/// Create a `Resume` instruction
+pub fn resume(
+    token_program_id: &Pubkey,
+    mint: &Pubkey,
+    authority: &Pubkey,
+    signers: &[&Pubkey],
+) -> Result<Instruction, ProgramError> {
+    check_program_account(token_program_id)?;
+    let mut accounts = vec![
+        AccountMeta::new(*mint, false),
+        AccountMeta::new_readonly(*authority, signers.is_empty()),
+    ];
+    for signer_pubkey in signers.iter() {
+        accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
+    }
+    Ok(encode_instruction(
+        token_program_id,
+        accounts,
+        TokenInstruction::PausableExtension,
+        PausableInstruction::Resume,
+        &(),
+    ))
+}

--- a/token/program-2022/src/extension/pausable/mod.rs
+++ b/token/program-2022/src/extension/pausable/mod.rs
@@ -1,0 +1,39 @@
+#[cfg(feature = "serde-traits")]
+use serde::{Deserialize, Serialize};
+use {
+    crate::extension::{Extension, ExtensionType},
+    bytemuck::{Pod, Zeroable},
+    spl_pod::{optional_keys::OptionalNonZeroPubkey, primitives::PodBool},
+};
+
+/// Instruction types for the pausable extension
+pub mod instruction;
+/// Instruction processor for the pausable extension
+pub mod processor;
+
+/// Indicates that the tokens from this mint can be paused
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(C)]
+pub struct PausableConfig {
+    /// Authority that can pause or resume activity on the mint
+    pub authority: OptionalNonZeroPubkey,
+    /// Whether minting / transferring / burning tokens is paused
+    pub paused: PodBool,
+}
+
+/// Indicates that the tokens from this account belong to a pausable mint
+#[cfg_attr(feature = "serde-traits", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-traits", serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct PausableAccount;
+
+impl Extension for PausableConfig {
+    const TYPE: ExtensionType = ExtensionType::Pausable;
+}
+
+impl Extension for PausableAccount {
+    const TYPE: ExtensionType = ExtensionType::PausableAccount;
+}

--- a/token/program-2022/src/extension/pausable/processor.rs
+++ b/token/program-2022/src/extension/pausable/processor.rs
@@ -1,0 +1,91 @@
+use {
+    crate::{
+        check_program_account,
+        error::TokenError,
+        extension::{
+            pausable::{
+                instruction::{InitializeInstructionData, PausableInstruction},
+                PausableConfig,
+            },
+            BaseStateWithExtensionsMut, PodStateWithExtensionsMut,
+        },
+        instruction::{decode_instruction_data, decode_instruction_type},
+        pod::PodMint,
+        processor::Processor,
+    },
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        entrypoint::ProgramResult,
+        msg,
+        pubkey::Pubkey,
+    },
+};
+
+fn process_initialize(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    authority: &Pubkey,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack_uninitialized(&mut mint_data)?;
+
+    let extension = mint.init_extension::<PausableConfig>(true)?;
+    extension.authority = Some(*authority).try_into()?;
+
+    Ok(())
+}
+
+/// Pause minting / burning / transferring on the mint
+fn process_toggle_pause(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    pause: bool,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_account_info = next_account_info(account_info_iter)?;
+    let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_info.data_len();
+
+    let mut mint_data = mint_account_info.data.borrow_mut();
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack(&mut mint_data)?;
+    let extension = mint.get_extension_mut::<PausableConfig>()?;
+    let maybe_authority: Option<Pubkey> = extension.authority.into();
+    let authority = maybe_authority.ok_or(TokenError::AuthorityTypeNotSupported)?;
+
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        authority_info,
+        authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    extension.paused = pause.into();
+    Ok(())
+}
+
+pub(crate) fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    check_program_account(program_id)?;
+
+    match decode_instruction_type(input)? {
+        PausableInstruction::Initialize => {
+            msg!("PausableInstruction::Initialize");
+            let InitializeInstructionData { authority } = decode_instruction_data(input)?;
+            process_initialize(program_id, accounts, authority)
+        }
+        PausableInstruction::Pause => {
+            msg!("PausableInstruction::Pause");
+            process_toggle_pause(program_id, accounts, true /* pause */)
+        }
+        PausableInstruction::Resume => {
+            msg!("PausableInstruction::Resume");
+            process_toggle_pause(program_id, accounts, false /* resume */)
+        }
+    }
+}

--- a/token/program-2022/src/extension/pausable/processor.rs
+++ b/token/program-2022/src/extension/pausable/processor.rs
@@ -37,7 +37,7 @@ fn process_initialize(
     Ok(())
 }
 
-/// Pause minting / burning / transferring on the mint
+/// Pause or resume minting / burning / transferring on the mint
 fn process_toggle_pause(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/token/program-2022/src/instruction.rs
+++ b/token/program-2022/src/instruction.rs
@@ -715,6 +715,8 @@ pub enum TokenInstruction<'a> {
     /// Instruction prefix for instructions to the scaled ui amount
     /// extension
     ScaledUiAmountExtension,
+    /// Instruction prefix for instructions to the pausable extension
+    PausableExtension,
 }
 impl<'a> TokenInstruction<'a> {
     /// Unpacks a byte buffer into a
@@ -856,6 +858,7 @@ impl<'a> TokenInstruction<'a> {
             41 => Self::GroupMemberPointerExtension,
             42 => Self::ConfidentialMintBurnExtension,
             43 => Self::ScaledUiAmountExtension,
+            44 => Self::PausableExtension,
             _ => return Err(TokenError::InvalidInstruction.into()),
         })
     }
@@ -1033,6 +1036,9 @@ impl<'a> TokenInstruction<'a> {
             &Self::ScaledUiAmountExtension => {
                 buf.push(43);
             }
+            &Self::PausableExtension => {
+                buf.push(44);
+            }
         };
         buf
     }
@@ -1132,6 +1138,8 @@ pub enum AuthorityType {
     GroupMemberPointer,
     /// Authority to set the UI amount scale
     ScaledUiAmount,
+    /// Authority to pause or resume minting / transferring / burning
+    Pause,
 }
 
 impl AuthorityType {
@@ -1153,6 +1161,7 @@ impl AuthorityType {
             AuthorityType::GroupPointer => 13,
             AuthorityType::GroupMemberPointer => 14,
             AuthorityType::ScaledUiAmount => 15,
+            AuthorityType::Pause => 16,
         }
     }
 
@@ -1174,6 +1183,7 @@ impl AuthorityType {
             13 => Ok(AuthorityType::GroupPointer),
             14 => Ok(AuthorityType::GroupMemberPointer),
             15 => Ok(AuthorityType::ScaledUiAmount),
+            16 => Ok(AuthorityType::Pause),
             _ => Err(TokenError::InvalidInstruction.into()),
         }
     }

--- a/token/program-2022/src/pod_instruction.rs
+++ b/token/program-2022/src/pod_instruction.rs
@@ -116,6 +116,7 @@ pub(crate) enum PodTokenInstruction {
     GroupMemberPointerExtension,
     ConfidentialMintBurnExtension,
     ScaledUiAmountExtension,
+    PausableExtension,
 }
 
 fn unpack_pubkey_option(input: &[u8]) -> Result<PodCOption<Pubkey>, ProgramError> {


### PR DESCRIPTION
#### Problem

Users want a more Ethereum-style token experience by being able to "pause" their token, similar to the "Pausable" interface. When a mint is paused, tokens cannot be minted, burned, or transferred.

#### Summary of changes

Add the extension and some tests. It covers the following interactions:

* mint / mint-checked
* burn / burn-checked
* transfer / transfer-checked / transfer-with-fee
* confidential transfer / confidential transfer with fee
* confidential mint / confidential burn
* confidential deposit / confidential withdraw

Unfortunately, the confidential mint / burn extension doesn't have testing, so I couldn't get a full end-to-end test for it.

Also note that it's still possible to:

* move withheld tokens
* initialize token accounts
* close token accounts
* set authority
* freeze / thaw
* approve / revoke
* almost every other bit of extension management

cc @gitteri @jnwng 