### PR TITLE
CI: Add idna to ignore

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -23,5 +23,16 @@ cargo_audit_ignores=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
   # Solution:  Upgrade to >=0.12.3
   --ignore RUSTSEC-2024-0376
+
+  # Crate:     idna
+  # Version:   0.1.5
+  # Title:     `idna` accepts Punycode labels that do not produce any non-ASCII when decoded
+  # Date:      2024-12-09
+  # ID:        RUSTSEC-2024-0421
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0421
+  # Solution:  Upgrade to >=1.0.0
+  # need to solve this depentant tree:
+  # jsonrpc-core-client v18.0.0 -> jsonrpc-client-transports v18.0.0 -> url v1.7.2 -> idna v0.1.5
+  --ignore RUSTSEC-2024-0421
 )
 cargo +"$rust_stable" audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

Audit is failing due to an issue on idna.

#### Summary of changes

Since the dependency is pretty buried, do the same thing as https://github.com/anza-xyz/agave/pull/4014 and ignore it.