### PR TITLE
token-cli: Use the `commitment` field from Solana config

### DIFF
--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -100,10 +100,12 @@ impl<'a> Config<'a> {
                 .unwrap_or(&cli_config.json_rpc_url),
         );
         let websocket_url = solana_cli_config::Config::compute_websocket_url(&json_rpc_url);
+        let commitment_config = CommitmentConfig::from_str(&cli_config.commitment)
+            .unwrap_or_else(|_| CommitmentConfig::confirmed());
         let rpc_client = Arc::new(RpcClient::new_with_timeouts_and_commitment(
             json_rpc_url,
             DEFAULT_RPC_TIMEOUT,
-            CommitmentConfig::confirmed(),
+            commitment_config,
             DEFAULT_CONFIRM_TX_TIMEOUT,
         ));
         let sign_only = matches.try_contains_id(SIGN_ONLY_ARG.name).unwrap_or(false);


### PR DESCRIPTION
### Problem

`spl-token` CLI doesn't respect the `commitment` field of Solana config when creating the RPC client.

See https://github.com/solana-labs/solana-program-library/issues/7590 for more details.

### Summary of changes

Use the `confirmation` field from the Solana config when creating the RPC client.

**Note:** This won't affect any users (unless they've overridden the `commitment` field) because [`confirmed` is already the default commitment of Solana config](https://github.com/anza-xyz/agave/blob/9e59baae79570628163d95a169e40f11b1db5109/cli-config/src/config.rs#L88).

Resolves https://github.com/solana-labs/solana-program-library/issues/7590