### PR TITLE
token-client: Make confirmation of `ProgramRpcClientSendTransaction` optional

### DIFF
--- a/single-pool/cli/src/config.rs
+++ b/single-pool/cli/src/config.rs
@@ -65,7 +65,7 @@ impl Config {
         // and program client
         let program_client = Arc::new(ProgramRpcClient::new(
             rpc_client.clone(),
-            ProgramRpcClientSendTransaction,
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
         ));
 
         // resolve default signer

--- a/single-pool/cli/tests/test.rs
+++ b/single-pool/cli/tests/test.rs
@@ -56,7 +56,7 @@ async fn setup(initialize: bool) -> Env {
     let rpc_client = Arc::new(validator.get_async_rpc_client());
     let program_client: PClient = Arc::new(ProgramRpcClient::new(
         rpc_client.clone(),
-        ProgramRpcClientSendTransaction,
+        ProgramRpcClientSendTransaction::new_with_confirmation(),
     ));
 
     // write the payer to disk

--- a/token-upgrade/cli/src/main.rs
+++ b/token-upgrade/cli/src/main.rs
@@ -89,7 +89,7 @@ async fn process_create_escrow_account(
 
     let program_client = Arc::new(ProgramRpcClient::new(
         rpc_client.clone(),
-        ProgramRpcClientSendTransaction,
+        ProgramRpcClientSendTransaction::new_with_confirmation(),
     ));
     let token = Token::new(
         program_client.clone(),
@@ -545,7 +545,7 @@ mod test {
         let rpc_client = Arc::new(test_validator.get_async_rpc_client());
         let client = Arc::new(ProgramRpcClient::new(
             rpc_client.clone(),
-            ProgramRpcClientSendTransaction,
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
         ));
 
         let mint_authority = Keypair::new();
@@ -614,7 +614,7 @@ mod test {
         let rpc_client = Arc::new(test_validator.get_async_rpc_client());
         let client = Arc::new(ProgramRpcClient::new(
             rpc_client.clone(),
-            ProgramRpcClientSendTransaction,
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
         ));
 
         let mint_authority = Keypair::new();
@@ -721,7 +721,7 @@ mod test {
         let rpc_client = Arc::new(test_validator.get_async_rpc_client());
         let client = Arc::new(ProgramRpcClient::new(
             rpc_client.clone(),
-            ProgramRpcClientSendTransaction,
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
         ));
 
         let mint_authority = Keypair::new();

--- a/token/cli/src/config.rs
+++ b/token/cli/src/config.rs
@@ -116,12 +116,12 @@ impl<'a> Config<'a> {
                 .unwrap_or_default();
             Arc::new(ProgramOfflineClient::new(
                 blockhash,
-                ProgramRpcClientSendTransaction,
+                ProgramRpcClientSendTransaction::new(),
             ))
         } else {
             Arc::new(ProgramRpcClient::new(
                 rpc_client.clone(),
-                ProgramRpcClientSendTransaction,
+                ProgramRpcClientSendTransaction::new(),
             ))
         };
         Self::new_with_clients_and_ws_url(

--- a/token/cli/tests/command.rs
+++ b/token/cli/tests/command.rs
@@ -190,9 +190,11 @@ fn test_config_with_default_signer<'a>(
 ) -> Config<'a> {
     let websocket_url = test_validator.rpc_pubsub_url();
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
-    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> = Arc::new(
-        ProgramRpcClient::new(rpc_client.clone(), ProgramRpcClientSendTransaction),
-    );
+    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> =
+        Arc::new(ProgramRpcClient::new(
+            rpc_client.clone(),
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
+        ));
     Config {
         rpc_client,
         program_client,
@@ -219,9 +221,11 @@ fn test_config_without_default_signer<'a>(
 ) -> Config<'a> {
     let websocket_url = test_validator.rpc_pubsub_url();
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
-    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> = Arc::new(
-        ProgramRpcClient::new(rpc_client.clone(), ProgramRpcClientSendTransaction),
-    );
+    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> =
+        Arc::new(ProgramRpcClient::new(
+            rpc_client.clone(),
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
+        ));
     Config {
         rpc_client,
         program_client,
@@ -3132,7 +3136,7 @@ async fn do_offline_multisig_transfer(
         let offline_program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> =
             Arc::new(ProgramOfflineClient::new(
                 blockhash,
-                ProgramRpcClientSendTransaction,
+                ProgramRpcClientSendTransaction::new_with_confirmation(),
             ));
         let mut args = vec![
             "spl-token".to_string(),
@@ -3192,9 +3196,11 @@ async fn do_offline_multisig_transfer(
         assert!(!absent_signers.contains(&token.to_string()));
 
         // now send the transaction
-        let rpc_program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> = Arc::new(
-            ProgramRpcClient::new(config.rpc_client.clone(), ProgramRpcClientSendTransaction),
-        );
+        let rpc_program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> =
+            Arc::new(ProgramRpcClient::new(
+                config.rpc_client.clone(),
+                ProgramRpcClientSendTransaction::new_with_confirmation(),
+            ));
         config.program_client = rpc_program_client;
         let mut args = vec![
             "spl-token".to_string(),
@@ -3849,9 +3855,11 @@ async fn transfer_hook(test_validator: &TestValidator, payer: &Keypair) {
     // Make sure that parsing transfer hook accounts works
     let real_program_client = config.program_client;
     let blockhash = Hash::default();
-    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> = Arc::new(
-        ProgramOfflineClient::new(blockhash, ProgramRpcClientSendTransaction),
-    );
+    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> =
+        Arc::new(ProgramOfflineClient::new(
+            blockhash,
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
+        ));
     config.program_client = program_client;
     let _result = exec_test_cmd(
         &config,
@@ -3965,9 +3973,11 @@ async fn transfer_hook_with_transfer_fee(test_validator: &TestValidator, payer: 
 
     // Make sure that parsing transfer hook accounts and expected-fee works
     let blockhash = Hash::default();
-    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> = Arc::new(
-        ProgramOfflineClient::new(blockhash, ProgramRpcClientSendTransaction),
-    );
+    let program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>> =
+        Arc::new(ProgramOfflineClient::new(
+            blockhash,
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
+        ));
     config.program_client = program_client;
 
     let _result = exec_test_cmd(

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -126,7 +126,8 @@ pub struct ProgramRpcClientSendTransaction {
 }
 
 impl ProgramRpcClientSendTransaction {
-    /// Create an instance that sends the transaction **without** waiting for confirmation.
+    /// Create an instance that sends the transaction **without** waiting for
+    /// confirmation.
     pub fn new() -> Self {
         Self::default()
     }

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -120,7 +120,10 @@ pub trait SimulateTransactionRpc: SimulateTransaction {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ProgramRpcClientSendTransaction;
+pub struct ProgramRpcClientSendTransaction {
+    /// Confirm the transaction after sending it
+    confirm: bool,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RpcClientResponse {

--- a/token/client/src/client.rs
+++ b/token/client/src/client.rs
@@ -125,6 +125,18 @@ pub struct ProgramRpcClientSendTransaction {
     confirm: bool,
 }
 
+impl ProgramRpcClientSendTransaction {
+    /// Create an instance that sends the transaction **without** waiting for confirmation.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create an instance that sends and confirms the transaction.
+    pub fn new_with_confirmation() -> Self {
+        Self { confirm: true }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RpcClientResponse {
     Signature(Signature),

--- a/token/transfer-hook/cli/src/main.rs
+++ b/token/transfer-hook/cli/src/main.rs
@@ -601,7 +601,7 @@ mod test {
         let rpc_client = Arc::new(test_validator.get_async_rpc_client());
         let client = Arc::new(ProgramRpcClient::new(
             rpc_client.clone(),
-            ProgramRpcClientSendTransaction,
+            ProgramRpcClientSendTransaction::new_with_confirmation(),
         ));
 
         let token = Token::new(


### PR DESCRIPTION
### Problem

`SendTransactionRpc` implementation of `ProgramRpcClientSendTransaction` both sends and confirms the transaction:

https://github.com/solana-labs/solana-program-library/blob/7e6c031b96879a34d0e49ce7da204bd0a966f229/token/client/src/client.rs#L136-L154

The behavior is misleading, especially considering its naming, and it's also the root cause of the problem mentioned in https://github.com/solana-labs/solana-program-library/issues/7595.

### Summary of changes

- Convert `ProgramRpcClientSendTransaction` to a named struct and add `confirm` field
- Use the `confirm` field to decide whether to confirm the sent transaction
- Add `new` and `new_with_confirmation` methods to the `ProgramRpcClientSendTransaction` struct
- Use `ProgramRpcClientSendTransaction::new` during token-cli's `Config` creation
- Use `ProgramRpcClientSendTransaction::new_with_confirmation` everywhere else in the repository to keep the changes minimal and behavior the same

**Note:** I found this solution to be simpler than adding a new type (like mentioned in https://github.com/solana-labs/solana-program-library/pull/3139#pullrequestreview-962705328), but I'd be down to implement it that way too if that's what you prefer.

Fixes https://github.com/solana-labs/solana-program-library/issues/7595