### PR TITLE
Fix #7549

### DIFF
--- a/token/js/src/extensions/transferFee/instructions.ts
+++ b/token/js/src/extensions/transferFee/instructions.ts
@@ -51,10 +51,10 @@ function computeCombinationOfSpans(combinations: number[], fields: Layout<any>[]
         return combinations;
     }
     if (fields[index] instanceof COptionPublicKeyLayout) {
-        computeCombinationOfSpans(fields, index + 1, partialResult + COptionPublicKeyLayout.spanWhenNull);
-        computeCombinationOfSpans(fields, index + 1, partialResult + COptionPublicKeyLayout.spanWithValue);
+        computeCombinationOfSpans(combinations, fields, index + 1, partialResult + COptionPublicKeyLayout.spanWhenNull);
+        computeCombinationOfSpans(combinations, fields, index + 1, partialResult + COptionPublicKeyLayout.spanWithValue);
     } else {
-        computeCombinationOfSpans(fields, index + 1, partialResult + fields[index].span);
+        computeCombinationOfSpans(combinations, fields, index + 1, partialResult + fields[index].span);
     }
     return combinations;
 }

--- a/token/js/src/instructions/setAuthority.ts
+++ b/token/js/src/instructions/setAuthority.ts
@@ -116,7 +116,6 @@ export function decodeSetAuthorityInstruction(
     programId = TOKEN_PROGRAM_ID,
 ): DecodedSetAuthorityInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
-    // TODO fix
     if (instruction.data.length !== SPAN_WITHOUT_NEW_AUTHORITY
         && instruction.data.length !== SPAN_WITH_NEW_AUTHORITY) throw new TokenInvalidInstructionDataError();
 

--- a/token/js/src/serialization.ts
+++ b/token/js/src/serialization.ts
@@ -60,7 +60,7 @@ function computeCombinationsOfSpans(combinations: number[], fields: Layout<any>[
     return combinations;
 }
 
-export getSetOfPossibleSpans(struct: Structure): Set<number {
+export function getSetOfPossibleSpans(struct: Structure): Set<number> {
     return new Set<number>(
         computeCombinationsOfSpans([], struct.fields, 0, 0)
     );

--- a/token/js/src/serialization.ts
+++ b/token/js/src/serialization.ts
@@ -1,4 +1,4 @@
-import { Layout } from '@solana/buffer-layout';
+import { Layout, Structure } from '@solana/buffer-layout';
 import { publicKey } from '@solana/buffer-layout-utils';
 import type { PublicKey } from '@solana/web3.js';
 
@@ -44,4 +44,24 @@ export class COptionPublicKeyLayout extends Layout<PublicKey | null> {
         }
         return 1 + COptionPublicKeyLayout.spanWithValue;
     }
+}
+
+function computeCombinationsOfSpans(combinations: number[], fields: Layout<any>[], index: number, partialResult: number): number[] {
+    if (index >= fields.length) {
+        combinations.push(partialResult);
+        return combinations;
+    }
+    if (fields[index] instanceof COptionPublicKeyLayout) {
+        computeCombinationsOfSpans(combinations, fields, index + 1, partialResult + COptionPublicKeyLayout.spanWhenNull);
+        computeCombinationsOfSpans(combinations, fields, index + 1, partialResult + COptionPublicKeyLayout.spanWithValue);
+    } else {
+        computeCombinationsOfSpans(combinations, fields, index + 1, partialResult + fields[index].span);
+    }
+    return combinations;
+}
+
+export getSetOfPossibleSpans(struct: Structure): Set<number {
+    return new Set<number>(
+        computeCombinationsOfSpans([], struct.fields, 0, 0)
+    );
 }

--- a/token/js/src/serialization.ts
+++ b/token/js/src/serialization.ts
@@ -10,6 +10,14 @@ export class COptionPublicKeyLayout extends Layout<PublicKey | null> {
         this.publicKeyLayout = publicKey();
     }
 
+    static get spanWhenNull(): number {
+        return 1;
+    }
+
+    static get spanWithValue(): number {
+        return 1 + publicKey().span;
+    }
+
     decode(buffer: Uint8Array, offset: number = 0): PublicKey | null {
         const option = buffer[offset];
         if (option === 0) {
@@ -32,8 +40,8 @@ export class COptionPublicKeyLayout extends Layout<PublicKey | null> {
     getSpan(buffer?: Uint8Array, offset: number = 0): number {
         if (buffer) {
             const option = buffer[offset];
-            return option === 0 ? 1 : 1 + this.publicKeyLayout.span;
+            return option === 0 ? COptionPublicKeyLayout.spanWhenNull : 1 + COptionPublicKeyLayout.spanWithValue;
         }
-        return 1 + this.publicKeyLayout.span;
+        return 1 + COptionPublicKeyLayout.spanWithValue;
     }
 }

--- a/token/js/src/serialization.ts
+++ b/token/js/src/serialization.ts
@@ -60,7 +60,7 @@ function computeCombinationsOfSpans(combinations: number[], fields: Layout<any>[
     return combinations;
 }
 
-export function getSetOfPossibleSpans(struct: Structure): Set<number> {
+export function getSetOfPossibleSpans(struct: Structure<any>): Set<number> {
     return new Set<number>(
         computeCombinationsOfSpans([], struct.fields, 0, 0)
     );


### PR DESCRIPTION
As explained in #7549, `InitializeMint` and `InitializeMint2` without FreezeAuthority break `decodeInitializeMintInstruction` and `decodeInitializeMint2Instruction` respectively.

Since buffer layouts apparently don't support optional fields, this is currently a workaround. Indeed, this solution won't scale well when more than one optional field is present as it would require implementing the same logic for each combination of presence of each optional field.

The actual solution would require supporting optional `Layout`s in `buffer-layouts`, adapt the `Structure` layout to account for it and easily provide a list of spans, then re-implement `COptionPublicKeyLayout` with it and check in `decodeInitializeMintInstruction` and `decodeInitializeMint2Instruction` if the length of the buffer is in one of the values of spans provided by `Structure`.

Overall, I'd recommend not allowing optional fields, but rather have then set to a null value like 0 or -1.